### PR TITLE
NGPOC-379 : Add ability to display all fields for debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "moment": "^2.17.1",
     "ng2-bootstrap": "^1.1.16",
     "ng2-bs3-modal": "^0.10.4",
-    "ng2-openmrs-formentry": "git+https://github.com/AMPATH/ng2-opemmrs-formentry.git#v2.5.0-alpha",
+    "ng2-openmrs-formentry": "git+https://github.com/AMPATH/ng2-opemmrs-formentry.git#v2.5.0",
     "ng2-pagination": "^0.5.1",
     "ng2-pdf-viewer": "^1.0.1",
     "ng2-responsive": "^0.4.7",

--- a/src/app/app-settings/app-settings.component.css
+++ b/src/app/app-settings/app-settings.component.css
@@ -63,3 +63,59 @@ footer .inline p, footer a.inline {
   z-index: 2;
 }
 
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+}
+
+.switch input {display:none;}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #2196F3;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: 34px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}
+

--- a/src/app/app-settings/app-settings.component.html
+++ b/src/app/app-settings/app-settings.component.html
@@ -60,6 +60,21 @@
     </form>
   </div>
 
+   <div>
+  <div>
+    <form>
+      <div class="form-group">
+          <label class="control-label">FormEntry Debug Mode </label>
+          <div class="checkbox">
+              <label>
+                <input type="checkbox" id="debugMode" [(ngModel)]="hideFields"  name="hideFields" (change)="toggleDebugMode()">Display all fields
+              </label>
+          </div>
+      </div>
+    </form>
+  </div>
+   </div>
+
   <div class="action-buttons pull-right">
     <button class="btn btn-primary btn-large" type="submit" (click)="onDoneClick()">Done</button>
   </div>

--- a/src/app/app-settings/app-settings.component.spec.ts
+++ b/src/app/app-settings/app-settings.component.spec.ts
@@ -1,4 +1,3 @@
-import { CookieService } from 'ngx-cookie';
 import { DebugElement } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { provideRoutes } from '@angular/router';
@@ -18,6 +17,7 @@ import { ModalModule } from 'ngx-bootstrap/modal';
 import { AuthenticationService } from '../openmrs-api/authentication.service';
 import { SessionService } from '../openmrs-api/session.service';
 import { CookieModule } from 'ngx-cookie';
+import { CookieService } from 'angular2-cookie/services/cookies.service';
 
 describe('AppSettingsComponent Tests', () => {
   let comp: AppSettingsComponent;
@@ -56,7 +56,7 @@ describe('AppSettingsComponent Tests', () => {
   }));
 
   it('AppSettingsComponent should exist', () => {
-    expect(comp).toBeTruthy;
+    expect(comp).toBeTruthy();
   });
 
   it('Should display default Openmrs server url', () => {
@@ -68,5 +68,19 @@ describe('AppSettingsComponent Tests', () => {
     fixture.autoDetectChanges();
     let formElements = fixture.debugElement.queryAll(By.css('div .form-group'));
     expect(formElements[1].nativeElement.textContent).toContain(comp.etlServerUrls[0]);
+  });
+
+  it('Should display the Debug Mode Option', () => {
+    fixture.autoDetectChanges();
+    let debugEl = fixture.debugElement.queryAll(By.css('#debugMode'));
+    expect(debugEl.length).toEqual(1);
+  });
+
+  it('Should set cookie for debug mode if enabled', () => {
+    fixture.autoDetectChanges();
+    comp.hideFields = true;
+    comp.toggleDebugMode();
+    expect(comp.getDebugMode()).toBe('true');
+    comp.removeDebugCookie();
   });
 });

--- a/src/app/app-settings/app-settings.component.ts
+++ b/src/app/app-settings/app-settings.component.ts
@@ -4,6 +4,7 @@ import { AppSettingsService } from './app-settings.service';
 import { AuthenticationService } from '../openmrs-api/authentication.service';
 import { LocalStorageService } from '../utils/local-storage.service';
 import { ModalDirective } from 'ngx-bootstrap/modal';
+import { CookieService } from 'angular2-cookie/services/cookies.service';
 
 @Component({
   selector: 'app-settings',
@@ -16,13 +17,17 @@ export class AppSettingsComponent implements OnInit {
   public urlModal: ModalDirective;
   public newUrl: string;
   public urlPlaceholder: string;
-  public  urlType: string;
+  public urlType: string;
   public serverTemplates: Array<object> = this.getServerTemplates();
+  public cookieKey: string = 'formDebug';
+  public cookieVal: string;
+  public hideFields: boolean;
 
   constructor(private router: Router,
               private appSettingsService: AppSettingsService,
               private localStorageService: LocalStorageService,
-              private authenticationService: AuthenticationService) { }
+              private authenticationService: AuthenticationService,
+              private _cookieService: CookieService) { }
 
   public getServerTemplates(): Array<object> {
     return this.appSettingsService.getServerTemplates();
@@ -34,6 +39,8 @@ export class AppSettingsComponent implements OnInit {
     if (!window.location.host.match(new RegExp('localhost'))) {
       this.changeServerSettings(templates[0]);
     }
+
+    this.checkDebugMode();
 
   }
 
@@ -98,5 +105,66 @@ export class AppSettingsComponent implements OnInit {
     // return back to login page
     this.authenticationService.clearSessionCache();
     this.router.navigate(['/login']);
+  }
+
+  // check if debug cookie has been set
+
+  public checkDebugMode() {
+
+        let isCookieSet = this.getDebugMode();
+
+        if (isCookieSet === 'undefined') {
+               this.hideFields = false;
+           } else {
+              // get the value of the debug mode
+              if (isCookieSet === 'true') {
+                      this.hideFields = true;
+              } else {
+                      this.hideFields = false;
+              }
+        }
+
+  }
+
+  // get the debug cookie value
+
+  public getDebugMode() {
+
+      let debugModeCookie = this._cookieService.get(this.cookieKey);
+
+      if (typeof debugModeCookie === 'undefined') {
+        return debugModeCookie;
+      } else {
+        return debugModeCookie;
+      }
+
+  }
+
+  public toggleDebugMode() {
+      // check if hidefields cookie has been set
+
+      let isCookieSet = this.getDebugMode();
+
+      if (isCookieSet === 'true') {
+           // remove the initial cookie set
+           this._cookieService.remove(this.cookieKey);
+       } else {
+
+       }
+
+      this.cookieVal = '' + this.hideFields;
+
+      this._cookieService.put(this.cookieKey, this.cookieVal);
+  }
+   public removeDebugCookie() {
+
+      let isCookieSet = this.getDebugMode();
+
+      if (isCookieSet === 'true') {
+           // remove the cookie set
+           this._cookieService.remove(this.cookieKey);
+       } else {
+
+       }
   }
 }

--- a/src/app/app-settings/app-settings.module.ts
+++ b/src/app/app-settings/app-settings.module.ts
@@ -7,6 +7,7 @@ import { APP_SETTINGS_ROUTES } from './app-settings.routes';
 import { UtilsModule } from '../utils/utils.module';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { AppSettingsService } from './app-settings.service';
+import { CookieService } from 'angular2-cookie/services/cookies.service';
 
 @NgModule({
   imports: [
@@ -18,7 +19,8 @@ import { AppSettingsService } from './app-settings.service';
   ],
   declarations: [AppSettingsComponent],
   providers: [
-    AppSettingsService
+    AppSettingsService,
+    CookieService
   ],
   exports: [
     RouterModule


### PR DESCRIPTION
This module utilizes cookies.The input to activate debug mode has been placed on the settings page.
When one enables debug mode,a cookie for debug mode is created and set to true.
On formmentry module there is a service called DebugModeService that checks if debug mode is enabled or not.If it has been enabled then it sets the hider.hide property to false in hiders-disablers-factory -> getJsExpressionHider. If debug mode is disabled or has not been set then it uses the runnable.run() function to set the hider,hide property