### PR TITLE
Fixed null name display in encounters

### DIFF
--- a/src/app/patient-dashboard/common/patient-encounters/encounter-list.component.html
+++ b/src/app/patient-dashboard/common/patient-encounters/encounter-list.component.html
@@ -46,7 +46,7 @@
         <tr style="cursor: pointer;" *ngFor="let encounter of encounters  |  encounterTypeFilter:encounterFilterTypeArray | paginate: { itemsPerPage: 10, currentPage: page }; let i = index;">
           <td>{{encounter.encounterDatetime | date: 'MMM dd, yyyy hh:mm a'}}</td>
           <td>{{encounter.encounterType.display}}</td>
-          <td>{{encounter.form.name}}</td>
+          <td><span *ngIf="encounter.form">{{encounter.form.name}}</span></td>
           <td>{{encounter.location.display}}</td>
           <td>{{encounter.provider.display}}</td>
           <td>


### PR DESCRIPTION
Auto enrollment of differentiated care was generating encounters without form name.The null property was causing visits page to load without an end and breakages on some pages.