### PR TITLE
Refactored online-tracker.component to include a service (online-tracker-service)

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,12 +32,13 @@ import { CacheService } from 'ionic-cache';
 import { DataCacheService } from './shared/services/data-cache.service';
 import { FeedBackComponent } from './feedback';
 import { FormVisitTypeSearchModule } from
-'./patient-dashboard/common/form-visit-type-search/form-visit-type-search.module';
+    './patient-dashboard/common/form-visit-type-search/form-visit-type-search.module';
 import { BusyModule, BusyConfig } from 'angular2-busy';
 import { LabOrderSearchModule } from './lab-order-search/lab-order-search.module';
 import { ModalModule } from 'ngx-bootstrap/modal';
 
 import { CookieModule } from 'ngx-cookie';
+import { OnlineTrackerService } from './online-tracker/online-tracker.service';
 
 // Application wide providers
 const APP_PROVIDERS = [
@@ -113,6 +114,7 @@ export function httpClient(xhrBackend: XHRBackend, requestOptions: RequestOption
     AuthGuard,
     LoginGuard,
     LocalStorageService,
+    OnlineTrackerService,
     {
       provide: Http,
       useFactory: httpClient,

--- a/src/app/online-tracker/online-tracker.component.html
+++ b/src/app/online-tracker/online-tracker.component.html
@@ -1,0 +1,6 @@
+<p *ngIf="isOnline" class="text-bold"><i class="fa fa-circle text-success"></i>
+  <span></span>
+</p>
+<p *ngIf="!isOnline" class="text-bold"><i class="fa fa-circle text-danger"></i>
+  <span class="text-danger"><span *ngIf="isUpdating"> (updating...) </span></span>
+</p>

--- a/src/app/online-tracker/online-tracker.component.spec.ts
+++ b/src/app/online-tracker/online-tracker.component.spec.ts
@@ -1,0 +1,98 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, fakeAsync, ComponentFixture,
+  tick, discardPeriodicTasks } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { OnlineTrackerComponent } from './online-tracker.component';
+import { OnlineTrackerService } from './online-tracker.service';
+import { SessionService } from '../openmrs-api/session.service';
+import { MockBackend, MockConnection } from '@angular/http/testing';
+import { Http, Response, Headers, BaseRequestOptions, ResponseOptions } from '@angular/http';
+import { AppSettingsService } from './../app-settings/app-settings.service';
+import { LocalStorageService } from './../utils/local-storage.service';
+import { AppFeatureAnalytics } from './../shared/app-analytics/app-feature-analytics.service';
+
+class DataStub {
+
+  public updateOnlineStatus(): Promise<any> {
+    alert('Data stub call');
+    return Promise.resolve(true);
+  }
+
+}
+
+describe('Component: OnlineTracker', () => {
+  let fixture: ComponentFixture<OnlineTrackerComponent>;
+  let component: OnlineTrackerComponent;
+  let debugElement: DebugElement;
+  let dataStub: OnlineTrackerService;
+  let element;
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [OnlineTrackerComponent],
+      providers: [
+        { provide: OnlineTrackerService, useClass: DataStub },
+        {
+          provide: Http,
+          useFactory: (
+            backendInstance: MockBackend,
+            defaultOptions: BaseRequestOptions
+          ) => {
+            return new Http(backendInstance, defaultOptions);
+          },
+          deps: [MockBackend, BaseRequestOptions]
+        },
+        SessionService,
+        MockBackend,
+        BaseRequestOptions,
+        AppSettingsService,
+        LocalStorageService,
+        AppFeatureAnalytics
+      ]
+    })
+      .compileComponents()
+      .then(() => {
+
+        fixture = TestBed.createComponent(OnlineTrackerComponent);
+        debugElement = fixture.debugElement;
+        element = fixture.nativeElement;
+        component = fixture.componentInstance;
+        dataStub = fixture.debugElement.injector.get(OnlineTrackerService);
+
+      });
+  }));
+
+  it('should create an instance', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set online to true when updateOnline return true', fakeAsync(() => {
+    const spy = spyOn(dataStub, 'updateOnlineStatus').and.returnValue(
+      Promise.resolve(true)
+    );
+    fixture.detectChanges();
+    component.getOnlineStatus();
+    tick();
+    component.subscribeToTimer = false;
+    expect(component.isOnline).toBe(true);
+    expect(component.isUpdating).toBe(false);
+    expect(spy.calls.any()).toEqual(true);
+    discardPeriodicTasks();
+
+  }));
+
+  it('should set online to false when updateOnline return false', fakeAsync(() => {
+    const spy = spyOn(dataStub, 'updateOnlineStatus').and.returnValue(
+      Promise.resolve(false)
+    );
+    fixture.detectChanges();
+    component.getOnlineStatus();
+    tick();
+    component.subscribeToTimer = false;
+    expect(component.isOnline).toBe(false);
+    expect(component.isUpdating).toBe(true);
+    expect(spy.calls.any()).toEqual(true);
+    discardPeriodicTasks();
+
+  }));
+});

--- a/src/app/online-tracker/online-tracker.service.spec.ts
+++ b/src/app/online-tracker/online-tracker.service.spec.ts
@@ -1,0 +1,48 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async } from '@angular/core/testing';
+import { Observable } from 'rxjs/Rx';
+import {  BaseRequestOptions, Http, HttpModule, Response,
+  ResponseOptions, RequestMethod } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
+import { SessionService } from '../openmrs-api/session.service';
+import { OnlineTrackerService } from './online-tracker.service';
+import { AppSettingsService } from '../app-settings';
+import { LocalStorageService } from '../utils/local-storage.service';
+
+describe('Service: OnlineTracker', () => {
+  let onlineTrackerService: OnlineTrackerService;
+  let sessionServiceSpy: jasmine.SpyObj<SessionService>;
+  beforeEach(() => {
+    const spy = jasmine.createSpyObj('SessionService', ['getSession']);
+    TestBed.configureTestingModule({
+      providers: [
+        OnlineTrackerService,
+        {
+          provide: SessionService,
+          useValue: spy
+        },
+        MockBackend,
+        BaseRequestOptions,
+        {
+          provide: Http,
+          useFactory: (backend, options) => new Http(backend, options),
+          deps: [MockBackend, BaseRequestOptions]
+        },
+        AppSettingsService,
+        LocalStorageService
+      ]
+    });
+    onlineTrackerService = TestBed.get(OnlineTrackerService);
+    sessionServiceSpy = TestBed.get(SessionService);
+  });
+
+  it('should create an instance', () => {
+    expect(onlineTrackerService).toBeTruthy();
+  });
+
+  it('should get session when update online status is called', () => {
+    onlineTrackerService.updateOnlineStatus();
+    expect(sessionServiceSpy.getSession).toHaveBeenCalled();
+  });
+});

--- a/src/app/online-tracker/online-tracker.service.ts
+++ b/src/app/online-tracker/online-tracker.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { Observable, Subject, BehaviorSubject } from 'rxjs/Rx';
+import { SessionService } from '../openmrs-api/session.service';
+
+@Injectable()
+export class OnlineTrackerService {
+
+  public isOnline: boolean = false;
+
+  constructor(private _sessionService: SessionService) {
+
+  }
+
+  public updateOnlineStatus() {
+    // console.log('Online Tracker Service: updateOnlineStatus');
+    return new Promise((resolve, reject) => {
+
+      this._sessionService.getSession()
+        .subscribe(
+          (results) => {
+            this.isOnline = true;
+            resolve(this.isOnline);
+          }, (error) => {
+            this.isOnline = false;
+            resolve(this.isOnline);
+          });
+
+    });
+  }
+
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
online-tracker.component update


* **What is the current behavior?** (You can also link to an open issue here)
online-tracker.component.ts currently acts as an on/offline indicator as well as checking for internet connection.


* **What is the new behavior (if this is a feature change)?**
online-tracker.service.ts is created to act as a service for the online-tracker.component. The component now only acts as an on/offline indicator and relies on online-tracker.service to determine if there is connectivity.


* **Other information**:
This was done so we (Worcester team) can use the online-tracker-service for offline AMRS implementation.