### PR TITLE
Fixed MOH-731 Loading bug

### DIFF
--- a/src/app/hiv-care-lib/moh-731-report/moh-731-report-base.component.ts
+++ b/src/app/hiv-care-lib/moh-731-report/moh-731-report-base.component.ts
@@ -102,6 +102,7 @@ export class Moh731ReportBaseComponent implements OnInit {
     this.showPatientList = false;
     this.showTabularView = true;
     this.showPatientListLoader = false;
+    this.currentIndicator = '';
   }
 
   public onLoadCompleted(complete) {


### PR DESCRIPTION
This PR fixes bug in MOH-731 report where on navigating back to tabular view after generating patient list, the patient list would not load a second time
