### PR TITLE
Fixed a bug that made isUpdating true when offline

### DIFF
--- a/src/app/online-tracker/online-tracker.component.spec.ts
+++ b/src/app/online-tracker/online-tracker.component.spec.ts
@@ -90,7 +90,7 @@ describe('Component: OnlineTracker', () => {
     tick();
     component.subscribeToTimer = false;
     expect(component.isOnline).toBe(false);
-    expect(component.isUpdating).toBe(true);
+    expect(component.isUpdating).toBe(false);
     expect(spy.calls.any()).toEqual(true);
     discardPeriodicTasks();
 

--- a/src/app/online-tracker/online-tracker.component.ts
+++ b/src/app/online-tracker/online-tracker.component.ts
@@ -1,8 +1,5 @@
 import { Component, OnInit , OnDestroy } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { Http, Response, Headers } from '@angular/http';
-
-import { SessionService } from '../openmrs-api/session.service';
 import { OnlineTrackerService } from './online-tracker.service';
 
 @Component({
@@ -19,7 +16,6 @@ export class OnlineTrackerComponent implements OnInit, OnDestroy {
   }
 
   public ngOnInit() {
-    console.log('Tracker Loaded');
     this.timer = Observable.timer(1000, 30000);
     this.timer
       .takeWhile(() => this.subscribeToTimer)
@@ -28,17 +24,14 @@ export class OnlineTrackerComponent implements OnInit, OnDestroy {
 
   public ngOnDestroy() {
     this.subscribeToTimer = false;
-    console.log('Timer Unsubscription');
   }
 
   public getOnlineStatus() {
     this.isUpdating = true;
     this._onlineTrackerService.updateOnlineStatus()
       .then((results: any) => {
-        if (results) {
-          this.isOnline = results;
-          this.isUpdating = !results;
-        }
+        this.isOnline = results;
+        this.isUpdating = false;
       }).catch((error) => {
       this.isOnline = false;
       console.error('ERROR: GetOnline Status Error', error);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
While working on development of an offline login, I noticed that the online-tracker indicator in the bottom right would continuously display "(updating...)" when I went offline. After investigation, I think that this is due to a bug in the OnlineTrackerComponent.


* **What is the current behavior?** (You can also link to an open issue here)
The online indicator on the bottom right hand side of the screen is continuously displaying "updating..." if the user goes offline. I believe the problem is with the if statement on line 38 of the component, which updates isOnline = result (line 39) and isUpdating = !result (line 40) only when results is true.


* **What is the new behavior (if this is a feature change)?**
I took out the if statement, instead setting isOnline = result and isUpdating = false. The online indicator now updates with the correct status, and displays "updating..." only when the status is truly being updated.


* **Other information**:
