### PR TITLE
Travis build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: node_js
+dist: xenial
 node_js:
 - "8"
 services:
 - docker
+- xvfb
 before_install:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
-- sleep 3
   # Updating NPM to relevant version >= 3 on Node.JS LTS
 - npm i -g brfs
 script:


### PR DESCRIPTION
Fixes Travis builds failing on master with this error: 

dpkg-deb: error: archive has premature member 'control.tar.xz' before 'control.tar.gz'

More: https://github.com/travis-ci/travis-ci/issues/9361