### PR TITLE
HIV-426: Documented transfers not flagging yellow

### DIFF
--- a/src/app/patient-dashboard/hiv/program-snapshot/hiv-program-snapshot.component.html
+++ b/src/app/patient-dashboard/hiv/program-snapshot/hiv-program-snapshot.component.html
@@ -14,7 +14,7 @@
       <h4 class="component-title">Last Encounter</h4>
       <div class="col-md-12">
         <div class="full-width">
-          <p>Location: {{location?.name}}</p>
+          <p>Location: {{latestEncounterLocation?.name}}</p>
         </div>
       </div>
       <div class="snapshot-body">
@@ -60,16 +60,16 @@
                 {{ getPatientCareStatus(patientCareStatus) }}</span></p>
           </div>
         </div>
-        <div class="col-md-12" *ngIf="hasMoriskyScore && !ismoriskyScorePoorOrInadequate">
+        <div class="col-md-12" *ngIf="hasMoriskyScore && !isMoriskyScorePoorOrInadequate">
           <div class="col-md-6 col-xs-12">
             <p>Morisky Score: <span style=" font-weight: 500; padding: 2px 2px 2px 2px;">
-                {{moriskyScore}}{{MoriskyDenominator}} - {{moriskyRating}}</span></p>
+                {{moriskyScore}}{{moriskyDenominator}} - {{moriskyRating}}</span></p>
           </div>
         </div>
-        <div class="col-md-12" *ngIf="hasMoriskyScore && ismoriskyScorePoorOrInadequate">
+        <div class="col-md-12" *ngIf="hasMoriskyScore && isMoriskyScorePoorOrInadequate">
           <div class="col-md-6 col-xs-12">
             <p>Morisky Score: <span class="score" style="color: red; padding: 2px 2px 2px 2px;">
-                {{moriskyScore}}{{MoriskyDenominator}} - {{moriskyRating}}</span></p>
+                {{moriskyScore}}{{moriskyDenominator}} - {{moriskyRating}}</span></p>
           </div>
         </div>
         <div class="clear"></div>

--- a/src/app/patient-dashboard/hiv/program-snapshot/hiv-program-snapshot.component.spec.ts
+++ b/src/app/patient-dashboard/hiv/program-snapshot/hiv-program-snapshot.component.spec.ts
@@ -1,37 +1,59 @@
-import { TestBed, async, inject } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, async, tick, fakeAsync } from '@angular/core/testing';
 import { AppSettingsService } from '../../../app-settings/app-settings.service';
 import { HivSummaryResourceService } from '../../../etl-api/hiv-summary-resource.service';
-import { of, Observable } from 'rxjs';
 import { HivProgramSnapshotComponent } from './hiv-program-snapshot.component';
 import { ZeroVlPipe } from './../../../shared/pipes/zero-vl-pipe';
 
+import { of } from 'rxjs';
+
 import { LocationResourceService } from '../../../openmrs-api/location-resource.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { TodaysVitalsService } from '../../common/todays-vitals/todays-vitals.service';
-import { VisitResourceService } from 'src/app/openmrs-api/visit-resource.service';
-import { VitalsDatasource } from '../../common/todays-vitals/vitals.datasource';
 import { EncounterResourceService } from 'src/app/openmrs-api/encounter-resource.service';
-import { ProgramWorkFlowResourceService } from 'src/app/openmrs-api/program-workflow-resource.service';
-import { PatientResourceService } from 'src/app/openmrs-api/patient-resource.service';
-import { PatientService } from '../../services/patient.service';
-import { PatientProgramService } from '../../programs/patient-programs.service';
-import { ProgramResourceService } from 'src/app/openmrs-api/program-resource.service';
-import { ProgramService } from '../../programs/program.service';
-import { RoutesProviderService } from 'src/app/shared/dynamic-route/route-config-provider.service';
-import { ProgramEnrollmentResourceService } from 'src/app/openmrs-api/program-enrollment-resource.service';
-import { FakeAppFeatureAnalytics } from 'src/app/shared/app-analytics/app-feature-analytcis.mock';
-import { ProgramWorkFlowStateResourceService } from 'src/app/openmrs-api/program-workflow-state-resource.service';
+import { LocalStorageService } from '../../../utils/local-storage.service';
+import { SessionStorageService } from '../../../utils/session-storage.service';
+import { UserDefaultPropertiesService } from '../../../user-default-properties/user-default-properties.service';
+import { UserService } from '../../../openmrs-api/user.service';
+import { Patient } from '../../../models/patient.model';
 
 const summaryResult = {
-  'encounter_datetime': '2017-04-25T07:54:20.000Z',
-  'location_uuid': '123',
-  'rtc_date': '2017-05-22T21:00:00.000Z',
-  'arv_start_date': '2017-04-24T21:00:00.000Z',
-  'cur_arv_meds': 'ZIDOVUDINE AND LAMIVUDINE, LOPINAVIR AND RITONAVIR',
-  'vl_1': 927,
-  'is_clinical_encounter': 1,
-  'vl_1_date': '2016-12-01T21:00:00.000Z',
-  'encounter_type_name': 'YOUTHRETURN',
+  arv_start_date: '2018-07-11T09:00:00.000Z',
+  arv_first_regimen: '',
+  contraceptive_method: 1107,
+  cur_arv_meds: 'LAMIVUDINE, NEVIRAPINE, TENOFOVIR',
+  date_created: '2019-09-10T02:38:20.000Z',
+  death_date: null,
+  discordant_status: 0,
+  encounter_datetime: '2019-07-19T05:54:03.000Z',
+  encounter_id: 8889835,
+  encounter_type: 2,
+  encounter_type_name: 'ADULTRETURN',
+  enrollment_date: '2019-02-25T21:00:00.000Z',
+  enrollment_location_id: 195,
+  expected_vl_date: 0,
+  hiv_dna_pcr_1: null,
+  hiv_start_date: '2019-02-25T21:00:00.000Z',
+  is_clinical_encounter: 1,
+  location_id: 195,
+  location_uuid: '18c343eb-b353-462a-9139-b16606e6b6c2',
+  mdt_session_number: 1,
+  med_pickup_rtc_date: null,
+  out_of_care: null,
+  outreach_attempts: null,
+  patient_care_status: 6101,
+  person_id: 892556,
+  prev_arv_end_date: '2019-03-24T21:00:00.000Z',
+  prev_arv_start_date: null,
+  prev_clinical_datetime_hiv: '2019-07-08T01:44:44.000Z',
+  prev_clinical_location_id: 195,
+  prev_clinical_rtc_date_hiv: '2019-07-29T21:00:00.000Z',
+  prev_encounter_datetime_hiv: '2019-07-17T21:00:00.000Z',
+  prev_encounter_type_hiv: 99999,
+  prev_rtc_date: '2019-07-29T21:00:00.000Z',
+  rtc_date: '2019-07-29T10:00:00.000Z',
+  uuid: '4a6ff3c6-6f95-41c1-b403-cd210ab7afba',
+  vl_1: 2000,
+  vl_1_date: '2019-03-17T11:00:00.000Z'
 };
 
 class FakeHivSummaryResourceService {
@@ -50,6 +72,10 @@ class FakeAppSettingsService {
   getOpenmrsServer() {
     return 'openmrs-url';
   }
+
+  getOpenmrsRestbaseurl() {
+    return 'openmrs-rest-url';
+  }
 }
 
 class FakeLocationResourceService {
@@ -57,17 +83,114 @@ class FakeLocationResourceService {
   }
 
   getLocationByUuid(locationUuid, fromCache) {
-    return Observable.of(
+    return of(
       {
-        uuid: '123'
+        name: 'Location Test',
+        uuid: '18c343eb-b353-462a-9139-b16606e6b6c2'
       }
     );
   }
 }
 
+class FakeUserDefaultPropertiesService {
+  constructor() {}
+
+  getCurrentUserDefaultLocation() {
+    return 'Location Test';
+  }
+}
+
+class FakeEncounterResourceService {
+  constructor() {}
+
+  getEncounterByUuid(encounterUuid: string) {
+    return of(
+      {
+        encounterDatetime: '2019-02-25T11:15:14.000+0300',
+        encounterType: {
+          display: 'ADULTINITIAL',
+          uuid: '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f'
+        },
+        form: {
+          name: 'AMPATH POC Adult Return Visit Form v1.5',
+          uuid: 'e44b0612-33d6-4ea7-8334-a8286876146b'
+        },
+        location: {
+          display: 'Location Test',
+          uuid: '18c343eb-b353-462a-9139-b16606e6b6c2'
+        },
+        patient: {
+          uuid: '4a6ff3c6-6f95-41c1-b403-cd210ab7afba'
+        },
+        uuid: 'd673c1d7-718b-4f5c-83a9-4709f4922af9',
+        visit: {
+          visitType: {
+            name: 'RETURN HIV CLINIC VISIT'
+          },
+          display: 'RETURN HIV CLINIC VISIT @ Location Test - 02/25/2019 09:25',
+          startDatetime: '2019-06-07T09:25:21.000+0300',
+          stopDatetime: null
+        },
+        obs: [
+          {
+            uuid: 'c1fe5975-dab5-4bdd-911b-fb81b3769f6b',
+            obsDatetime: '2019-06-07T11:15:44.000+0300',
+            concept: {
+              uuid: '315472dc-2b5e-4add-b3b7-bbcf21a8959b',
+              name: {
+                display: 'MORISKY 4 MEDICATION ADHERENCE, TOTAL SCORE'
+              }
+            },
+            value: 0,
+            groupMembers: null
+          }
+        ]
+      }
+    );
+  }
+}
+
+const testPatient = new Patient({
+  allIdentifiers: '742403208-9,99966667',
+  commonIdentifiers: {
+    ampathMrsUId: '742403208-9',
+    amrsMrn: '',
+    cCC: '',
+    kenyaNationalId: ''
+  },
+  display: '742403208-9 - test Noble kakamegatest',
+  encounters: [
+    {
+      encounterDatetime: '2019-07-19T08:54:03.000+0300',
+      encounterType: {
+        display: 'ADULTRETURN',
+        uuid: '8d5b2be0-c2cc-11de-8d13-0010c6dffd0f'
+      },
+      form: {
+        name: 'AMPATH POC Adult Return Visit Form v1.5',
+        uuid: 'bcb914ea-1e03-4c7f-9fd5-1baba5841e78'
+      },
+      location: {
+        display: 'Location Test',
+        uuid: '18c343eb-b353-462a-9139-b16606e6b6c2'
+      },
+      patient: {
+        uuid: '4a6ff3c6-6f95-41c1-b403-cd210ab7afba'
+      },
+      uuid: '97d0173d-7665-418d-a812-638c7798868f'
+    }
+  ],
+  uuid: '4a6ff3c6-6f95-41c1-b403-cd210ab7afba'
+});
+
 describe('Component: HivProgramSnapshotComponent', () => {
-  let hivService: HivSummaryResourceService,
-    appSettingsService: AppSettingsService, component, fixture;
+  let hivService: HivSummaryResourceService;
+  let appSettingsService: AppSettingsService;
+  let component: HivProgramSnapshotComponent;
+  let fixture: ComponentFixture<HivProgramSnapshotComponent>;
+  let debugElement: DebugElement;
+  let nativeElement: HTMLElement;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -87,32 +210,33 @@ describe('Component: HivProgramSnapshotComponent', () => {
           provide: LocationResourceService,
           useClass: FakeLocationResourceService
         },
-        TodaysVitalsService,
-        VisitResourceService,
-        VitalsDatasource,
-        TodaysVitalsService,
-        EncounterResourceService,
-        ProgramWorkFlowResourceService,
-        PatientService,
-        PatientProgramService,
-        ProgramResourceService,
-        ProgramService,
-        RoutesProviderService,
-        PatientResourceService,
-        FakeAppFeatureAnalytics,
-        ProgramEnrollmentResourceService,
-        ProgramWorkFlowResourceService,
-        ProgramWorkFlowStateResourceService,
-
+        {
+          provide: EncounterResourceService,
+          useClass: FakeEncounterResourceService
+        },
+        LocalStorageService,
+        SessionStorageService,
+        {
+          provide: UserDefaultPropertiesService,
+          useClass: FakeUserDefaultPropertiesService
+        },
+        UserService
       ],
       declarations: [HivProgramSnapshotComponent, ZeroVlPipe]
-    }).compileComponents().then(() => {
-      hivService = TestBed.get(HivSummaryResourceService);
-      appSettingsService = TestBed.get(AppSettingsService);
-      fixture = TestBed.createComponent(HivProgramSnapshotComponent);
-      component = fixture.componentInstance;
-    });
+    }).compileComponents();
   }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HivProgramSnapshotComponent);
+    component = fixture.componentInstance;
+    appSettingsService = TestBed.get(AppSettingsService);
+    hivService = TestBed.get(HivSummaryResourceService);
+    debugElement = fixture.debugElement;
+    nativeElement = debugElement.nativeElement;
+
+    component.patient = testPatient;
+    component.hasMoriskyScore = true;
+  });
 
   afterEach(() => {
     TestBed.resetTestingModule();
@@ -127,17 +251,74 @@ describe('Component: HivProgramSnapshotComponent', () => {
     expect(component.hasError).toEqual(false);
     expect(component.hasData).toEqual(false);
     expect(component.patientData).toEqual({});
-    expect(component.location).toEqual({});
+    expect(component.latestEncounterLocation).toEqual({});
     done();
   });
 
-  it('should set patient data and location when `getHivSummary` is called',
-    inject([HivSummaryResourceService],
-      (hs: HivSummaryResourceService) => {
-        component.getHivSummary('uuid');
-        expect(component.patientData).toEqual(summaryResult);
-        // expect(component.location).toEqual({ uuid: '123' });
-      })
-  );
+  it('should have all of its methods defined', () => {
+    expect(component.ngOnInit).toBeDefined();
+    expect(component.getHivSummary).toBeDefined();
+    expect(component.resolveLastEncounterLocation).toBeDefined();
+    expect(component.getPatientCareStatus).toBeDefined();
+    expect(component.getMoriskyScore).toBeDefined();
+    expect(component.getPreviousEncounters).toBeDefined();
+    expect(component.getPreviousEncounterDetails).toBeDefined();
+    expect(component.getLastAdultReturnEncounterDate).toBeDefined();
+    expect(component.getMorisky4).toBeDefined();
+    expect(component.getMorisky8).toBeDefined();
+    expect(component.setNullMorisky).toBeDefined();
+    expect(component.getMaximumDate).toBeDefined();
+  });
 
+  it('should fetch the patient\'s hiv summary and morisky score when the component initializes', async(() => {
+    expect(component.hasError).toEqual(false);
+    expect(component.hasData).toEqual(false);
+    fixture.detectChanges();
+    expect(component.hasData).toEqual(false);
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(component.hasError).toEqual(false);
+      expect(component.loadingData).toEqual(false);
+      expect(component.hasLoadedData).toEqual(true);
+      expect(component.patientCareStatus).toEqual(6101); // Continue with care
+      expect(component.moriskyScore).toEqual(0);
+      expect(component.moriskyDenominator).toEqual('/4');
+      expect(component.moriskyScore4).toEqual(0);
+      expect(component.moriskyScore8).toBeFalsy();
+      expect(component.moriskyRating).toEqual('Good');
+      expect(component.isMoriskyScorePoorOrInadequate).toEqual(false);
+      const locationName = <HTMLElement>nativeElement.querySelector('div.full-width');
+      expect(locationName.innerText).toContain('Location Test');
+      const snapshotRows = nativeElement.querySelectorAll('div.col-md-6.col-xs-12');
+      expect(snapshotRows[0].textContent).toContain('Date: 19-07-2019');
+      expect(snapshotRows[1].textContent).toContain('Type: ADULTRETURN');
+      expect(snapshotRows[2].textContent).toContain('ARV Regimen: LAMIVUDINE, NEVIRAPINE, TENOFOVIR');
+      expect(snapshotRows[3].textContent).toContain('Last Viral Load: 2000  (17-03-2019)');
+      expect(snapshotRows[4].textContent).toContain('RTC Date: 29-07-2019');
+      expect(snapshotRows[5].textContent).toContain('Care Status:  Continue With Care');
+      expect(snapshotRows[6].textContent).toContain('Morisky Score:  0/4 - Good');
+    });
+  }));
+
+  it('should flag the patient\'s viral load red if VL > 1000 && (vl_1_date > (arv_start_date + 6 months))', async(() => {
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(component.isVirallyUnsuppressed).toBe(true);
+      const latestVl = <HTMLElement>nativeElement.querySelector('p.text-bold.red');
+      expect(latestVl.classList).toContain('text-bold');
+      expect(latestVl.classList).toContain('red');
+    });
+  }));
+
+  it('should determine the patient care status from the provided concept', async(() => {
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(component.patientCareStatus).toBeDefined();
+      expect(component.patientCareStatus).toEqual(6101);
+      const snapshotRows = nativeElement.querySelectorAll('div.col-md-6.col-xs-12');
+      expect(snapshotRows[5].textContent).toContain('Care Status:  Continue With Care');
+    });
+  }));
 });

--- a/src/app/patient-dashboard/hiv/program-snapshot/hiv-program-snapshot.component.ts
+++ b/src/app/patient-dashboard/hiv/program-snapshot/hiv-program-snapshot.component.ts
@@ -1,22 +1,16 @@
-/* tslint:disable-next-line: no-shadowed-variable */
+import { OnInit, Component, Input, Output, EventEmitter } from '@angular/core';
+
+import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
-import { Observable, Subscription } from 'rxjs';
-
-import { map } from 'rxjs/operators';
-import { OnInit, Component, Input, Output, EventEmitter } from '@angular/core';
-import { Http, Response } from '@angular/http';
-
-import * as Moment from 'moment';
-import { HivSummaryResourceService } from '../../../etl-api/hiv-summary-resource.service';
 import * as _ from 'lodash';
-import { Patient } from '../../../models/patient.model';
 import * as moment from 'moment';
+
+import { Patient } from '../../../models/patient.model';
+import { HivSummaryResourceService } from '../../../etl-api/hiv-summary-resource.service';
 import { LocationResourceService } from '../../../openmrs-api/location-resource.service';
-import { TodaysVitalsService } from '../../common/todays-vitals/todays-vitals.service';
 import { EncounterResourceService } from 'src/app/openmrs-api/encounter-resource.service';
-import { PatientService } from '../../services/patient.service';
-import { getRenderedText } from '@angular/core/src/render3';
+import { UserDefaultPropertiesService } from '../../../user-default-properties/user-default-properties.service';
 
 const mdtProgramUuid = 'c4246ff0-b081-460c-bcc5-b0678012659e';
 const stdProgramUuid = '781d85b0-1359-11df-a1f1-0026b9348838';
@@ -26,31 +20,33 @@ const stdProgramUuid = '781d85b0-1359-11df-a1f1-0026b9348838';
   templateUrl: './hiv-program-snapshot.component.html'
 })
 export class HivProgramSnapshotComponent implements OnInit {
+  @Input() public set program(program) {
+    this.showViremiaAlert = program.uuid === mdtProgramUuid ? true : false;
+    this.hasMoriskyScore = program.uuid === stdProgramUuid ? true : false;
+  }
   @Input() public patient: Patient;
+  @Output() public addBackground = new EventEmitter();
+
   public hasError = false;
   public hasData = false;
   public hasMoriskyScore = false;
+  public clinicalEncounters: any[] = [];
   public patientData: any = {};
   public loadingData = false;
   public hasLoadedData = false;
   public prev_encounter_date: any = '';
   public isVirallyUnsuppressed = false;
-  public isMoriskyProgram = false;
   public patientCareStatus: any;
-  @Output() public addBackground = new EventEmitter();
-  public location: any = {};
+  public hasTransferEncounter: boolean;
+  public latestEncounterLocation: any = {};
   public backgroundColor: any = {
     pink: 'pink',
     yellow: 'yellow'
   };
   public viremiaAlert: string;
   public showViremiaAlert: boolean;
-  lowViremia: boolean;
-  highViremia: boolean;
-  @Input() public set program(program) {
-    program.uuid === mdtProgramUuid ? this.showViremiaAlert = true : this.showViremiaAlert = false;
-    program.uuid === stdProgramUuid ? this.hasMoriskyScore = true : this.hasMoriskyScore = false;
-  }
+  public lowViremia: boolean;
+  public highViremia: boolean;
   public currentPatientSub: Subscription;
 
   public _patient: Patient = new Patient({});
@@ -60,15 +56,14 @@ export class HivProgramSnapshotComponent implements OnInit {
   public moriskyScore8: any = '';
   public ismoriskyScore8 = false;
   public ismoriskyScore4 = false;
-  public MoriskyDenominator: any = '';
+  public moriskyDenominator: any = '';
   public moriskyRating: any = '';
-  public ismoriskyScorePoorOrInadequate = false;
+  public isMoriskyScorePoorOrInadequate = false;
 
   constructor(private hivSummaryResourceService: HivSummaryResourceService,
-    private vitalService: TodaysVitalsService,
-    private _encounterResourceService: EncounterResourceService,
-    private patientService: PatientService,
-    private locationResource: LocationResourceService) {
+    private encounterResourceService: EncounterResourceService,
+    private locationResource: LocationResourceService,
+    private userDefaultPropertiesService: UserDefaultPropertiesService) {
 
   }
 
@@ -87,26 +82,33 @@ export class HivProgramSnapshotComponent implements OnInit {
   public getHivSummary(patientUuid) {
     this.loadingData = true;
     this.hivSummaryResourceService.getHivSummary(patientUuid, 0, 10).pipe(take(1)).subscribe((results) => {
-      this.loadingData = false;
-      this.hasLoadedData = true;
       let latestVlResult: any;
       let latestVlDate = '';
       let latestVl = null;
+
+      this.loadingData = false;
+      this.hasLoadedData = true;
+
       if (results[0]) {
-        this.patientCareStatus = results[0].patient_care_status;
         latestVlResult = this.getlatestVlResult(results);
         latestVlDate = latestVlResult.vl_1_date;
         latestVl = latestVlResult.vl_1;
         latestVl = latestVlResult.vl_1;
+        this.patientCareStatus = results[0].patient_care_status;
+
         if (this.showViremiaAlert) {
           this.checkViremia(latestVl);
         }
       }
+      this.hasTransferEncounter = results.find(result => result.encounterType = 116) ? true : false;
 
-      this.patientData = _.first(_.filter(results, (encounter: any) => {
+      this.clinicalEncounters = _.filter(results, (encounter: any) => {
         return encounter.is_clinical_encounter === 1;
-      }));
+      });
+
+      this.patientData = _.first(this.clinicalEncounters);
       const patientDataCopy = this.patientData;
+
       if (!_.isNil(this.patientData)) {
         // assign latest vl and vl_1_date
         this.patientData = Object.assign(patientDataCopy,
@@ -119,7 +121,7 @@ export class HivProgramSnapshotComponent implements OnInit {
           this.isVirallyUnsuppressed = true;
         }
         this.hasData = true;
-        this.location = null;
+        this.latestEncounterLocation = null;
         if (this.patientData.location_uuid) {
           this.resolveLastEncounterLocation(this.patientData.location_uuid);
         }
@@ -130,12 +132,13 @@ export class HivProgramSnapshotComponent implements OnInit {
   public resolveLastEncounterLocation(location_uuid) {
     this.locationResource.getLocationByUuid(location_uuid, true)
       .subscribe((location) => {
-        this.location = location;
+        this.latestEncounterLocation = location;
       }, (error) => {
         console.error('Error resolving locations', error);
       });
   }
-  public getPatientCareStatus(id: any) {
+
+  public getPatientCareStatus(care_status_id: any) {
     const translateMap = {
       '159': 'DECEASED',
       '9079': 'UNTRACEABLE',
@@ -143,12 +146,12 @@ export class HivProgramSnapshotComponent implements OnInit {
       '9036': 'HIV NEGATIVE, NO LONGER AT RISK',
       '9083': 'SELF DISENGAGED FROM CARE',
       '6101': 'CONTINUE WITH CARE',
+      '1285': 'TRANSFER CARE TO OTHER CENTER',
       '1286': 'TRANSFER TO AMPATH FACILITY',
-      '9068': 'TRANSFER TO AMPATH FACILITY, NON-AMRS',
       '1287': 'TRANSFER TO NON-AMPATH FACILITY',
+      '9068': 'TRANSFER TO AMPATH FACILITY, NON-AMRS',
       '9504': 'TRANSFER TO MATERNAL CHILD HEALTH',
       '1594': 'PATIENT TRANSFERRED OUT',
-      '1285': 'TRANSFER CARE TO OTHER CENTER',
       '9578': 'ENROLL IN AMPATH FACILITY',
       '9164': 'ENROLL CARE IN ANOTHER HEALTH FACILITY',
       '1732': 'AMPATH CLINIC TRANSFER',
@@ -157,20 +160,49 @@ export class HivProgramSnapshotComponent implements OnInit {
       '5622': 'OTHER'
     };
     // if it is past RTC Date by 1 week and status = continue, can you make background pink
-    if (this.patientCareStatus === 6101 &&
+    if (care_status_id === 6101 &&
       moment(this.patientData.rtc_date).add(1, 'week') < moment(new Date())) {
       const color = this.backgroundColor.pink;
       this.addBackground.emit(color);
     }
-    if (this.patientCareStatus === 1287) {
+
+    // if patient is a transfer out, apply a yellow background to the snapshot summary
+    if (this.isNonAmpathTransferOut(care_status_id) || this.isIntraAmpathTransferFromCurrentLocation(care_status_id)) {
       const color = this.backgroundColor.yellow;
       this.addBackground.emit(color);
     }
-    return this._toProperCase(translateMap[id]);
+
+    return this._toProperCase(translateMap[care_status_id]);
+  }
+
+  private isNonAmpathTransferOut(care_status_id) {
+    return care_status_id === 1287 && this.hasMatchingLocation() || care_status_id === 5622 && this.hasMatchingLocation();
+  }
+
+  private isIntraAmpathTransferFromCurrentLocation(care_status_id) {
+    const intraAmpathTransferOutConceptIds = [1285, 1286, 9068, 9504];
+    if (intraAmpathTransferOutConceptIds.includes(care_status_id) && this.hasMatchingLocation()) {
+      return true;
+    }
+
+    if (care_status_id === 9080 && this.hasTransferEncounter && this.hasMatchingLocation()) {
+      return true;
+    }
+
+    if (care_status_id === 1594 && this.hasMatchingLocation()) {
+      return true;
+    }
+    return false;
+  }
+
+  private hasMatchingLocation() {
+    const currentlyLoggedInLocation = this.userDefaultPropertiesService.getCurrentUserDefaultLocation();
+    if (this.latestEncounterLocation) {
+      return this.latestEncounterLocation.display === currentlyLoggedInLocation;
+    }
   }
 
   private getlatestVlResult(hivSummaryData) {
-
     const orderByVlDate = _.orderBy(hivSummaryData, (hivSummary) => {
       return moment(hivSummary.vl_1_date);
     }, ['desc']);
@@ -183,7 +215,9 @@ export class HivProgramSnapshotComponent implements OnInit {
       return txt.charAt(0).toUpperCase() +
         txt.substr(1).toLowerCase();
     });
-  } private checkViremia(latestVl) {
+  }
+
+  private checkViremia(latestVl) {
     if (latestVl >= 1 && latestVl <= 999) {
       this.lowViremia = true;
       this.viremiaAlert = 'Low';
@@ -193,6 +227,7 @@ export class HivProgramSnapshotComponent implements OnInit {
       this.viremiaAlert = 'High';
     }
   }
+
   public getMoriskyScore() {
     const previousEncounters = this.getPreviousEncounters(this.patient.encounters);
     this.getPreviousEncounterDetails(previousEncounters)
@@ -217,14 +252,13 @@ export class HivProgramSnapshotComponent implements OnInit {
           this.setNullMorisky();
         }
         if (this.moriskyScore >= 0 && this.moriskyScore <= 0.25) {
-          this.ismoriskyScorePoorOrInadequate = false;
+          this.isMoriskyScorePoorOrInadequate = false;
         } else if (this.moriskyScore >= 0.5) {
-          this.ismoriskyScorePoorOrInadequate = true;
+          this.isMoriskyScorePoorOrInadequate = true;
         }
       });
   }
 
-// Function to get All Encounters
   public getAllEncounters(encounters) {
     const allEncounters = [];
     encounters = this.patient.encounters;
@@ -234,13 +268,12 @@ export class HivProgramSnapshotComponent implements OnInit {
     return allEncounters;
   }
 
-// Function to get Previous Morisky Encounter Details
   public getPreviousEncounters(allEncounters) {
     const previousEncounters = [];
     _.each(allEncounters, (encounter: any) => {
       const encounterType = encounter.encounterType.uuid;
-      const encounterDate = Moment(encounter.encounterDatetime).format('YYYY-MM-DD-HH');
-      if (encounterType === '8d5b2be0-c2cc-11de-8d13-0010c6dffd0f') {
+      const encounterDate = moment(encounter.encounterDatetime).format('YYYY-MM-DD-HH');
+      if (encounterType === '8d5b2be0-c2cc-11de-8d13-0010c6dffd0f') { // Adult Return encounter
         if (encounterDate === this.getLastAdultReturnEncounterDate(allEncounters)) {
           previousEncounters.push(encounter);
       }
@@ -249,12 +282,11 @@ export class HivProgramSnapshotComponent implements OnInit {
     return previousEncounters;
   }
 
-// Function to get Last Adult Return Encounter Date
   public getLastAdultReturnEncounterDate(allEncounters) {
     const max_date: any[] = [];
     _.each(allEncounters, (encounter: any) => {
-      const encounterDate = Moment(encounter.encounterDatetime).format('YYYY-MM-DD-HH');
-      const today = Moment().format('YYYY-MM-DD-HH');
+      const encounterDate = moment(encounter.encounterDatetime).format('YYYY-MM-DD-HH');
+      const today = moment().format('YYYY-MM-DD-HH');
       if (encounterDate !== today) {
         max_date.push(encounterDate);
       }
@@ -262,7 +294,6 @@ export class HivProgramSnapshotComponent implements OnInit {
     return this.getMaximumDate(max_date);
   }
 
-// Function to get array Previous Morisky Encounter Details
   public getPreviousEncounterDetails(previousEncounters) {
     return new Promise((resolve, reject) => {
       const encounterWithDetails = [];
@@ -276,8 +307,8 @@ export class HivProgramSnapshotComponent implements OnInit {
       _.each(previousEncounters, (encounterDetail: any) => {
         const encounterUuid = encounterDetail.uuid;
         encounterCount++;
-        this._encounterResourceService.getEncounterByUuid(encounterUuid).pipe(
-/* tslint:disable-next-line: no-shadowed-variable */
+        this.encounterResourceService.getEncounterByUuid(encounterUuid).pipe(
+        /* tslint:disable-next-line: no-shadowed-variable */
           take(1)).subscribe((encounterDetail) => {
             encounterWithDetails.push(encounterDetail);
             resultCount++;
@@ -287,10 +318,9 @@ export class HivProgramSnapshotComponent implements OnInit {
     });
   }
 
-// Function to get Morisky 4
   public getMorisky4() {
     this.moriskyScore = this.moriskyScore4;
-    this.MoriskyDenominator = '/4';
+    this.moriskyDenominator = '/4';
     if (this.moriskyScore === 0) {
       this.moriskyRating = 'Good';
     } else if (this.moriskyScore > 0 && this.moriskyScore < 3) {
@@ -298,23 +328,19 @@ export class HivProgramSnapshotComponent implements OnInit {
     }
   }
 
-// Function to get Morisky 8
   public getMorisky8() {
     this.moriskyScore = this.moriskyScore8;
-    this.MoriskyDenominator = '/8';
+    this.moriskyDenominator = '/8';
     this.moriskyRating = 'Poor';
-    this.ismoriskyScorePoorOrInadequate = true;
+    this.isMoriskyScorePoorOrInadequate = true;
   }
 
-// Function to get NUll Morisky score
   public setNullMorisky() {
     this.moriskyScore = '';
-    this.MoriskyDenominator = '';
+    this.moriskyDenominator = '';
     this.moriskyRating = 'No value';
   }
 
-
- // Function to get the maximum date in an array
   public getMaximumDate(all_dates) {
     let max_dt = all_dates[0],
       max_dtObj = new Date(all_dates[0]);


### PR DESCRIPTION
Fixes issue where documented transfers were not being flagged on the HIV summary snapshot. Transfers are now going to be flagged as follows:

- Transfers from one AMPATH clinic to another AMPATH clinic are going to have a yellow background applied to the summary snapshot when the user viewing the patient's landing page is logged in to the location where the patient has been transferred to.

- Transfers from AMPATH clinics to Non-AMPATH clinics are going to have a yellow background applied to the summary snapshot when the user viewing the patient's landing page is logged in to the location where the patient has been transferred from.