### PR TITLE
HIV-451: Transfer state being cached after effecting transfers

### DIFF
--- a/src/app/patient-dashboard/common/formentry/patient-transfer.service.ts
+++ b/src/app/patient-dashboard/common/formentry/patient-transfer.service.ts
@@ -232,4 +232,11 @@ export class PatientTransferService {
     return this.componentRef.form.searchNodeByQuestionId(questionId);
   }
 
+  public clearTransferState() {
+    this.setTransferState(null);
+  }
+
+  private setTransferState(state: any) {
+    this.transferState.next(state);
+  }
 }

--- a/src/app/program-manager/edit-program/edit-program-location.component.ts
+++ b/src/app/program-manager/edit-program/edit-program-location.component.ts
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 import { Patient } from '../../models/patient.model';
 import { ProgramManagerService } from '../program-manager.service';
 import { PatientResourceService } from '../../openmrs-api/patient-resource.service';
+import { PatientTransferService } from '../../patient-dashboard/common/formentry/patient-transfer.service';
 import { Observable } from 'rxjs';
 import * as moment from 'moment';
 import { ActivatedRoute } from '@angular/router';
@@ -43,7 +44,8 @@ export class EditProgramLocationComponent implements OnInit {
 
   constructor(private programManagerService: ProgramManagerService,
               public route: ActivatedRoute,
-              private patientResourceService: PatientResourceService) {
+              private patientResourceService: PatientResourceService,
+              private patientTransferService: PatientTransferService) {
     this.dateEnrolled = moment().format('YYYY-MM-DD');
   }
 
@@ -69,6 +71,7 @@ export class EditProgramLocationComponent implements OnInit {
         localStorage.removeItem('careStatus');
         localStorage.removeItem('transferRTC');
         this.locationChangeComplete.next([newProgram]);
+        this.patientTransferService.clearTransferState();
       }
     }, (err) => {
       console.log(err);

--- a/src/app/program-manager/edit-program/edit-program.component.ts
+++ b/src/app/program-manager/edit-program/edit-program.component.ts
@@ -6,6 +6,7 @@ import * as _ from 'lodash';
 
 import { ProgramManagerBaseComponent } from '../base/program-manager-base.component';
 import { PatientService } from '../../patient-dashboard/services/patient.service';
+import { PatientTransferService } from '../../patient-dashboard/common/formentry/patient-transfer.service';
 import { ProgramService } from '../../patient-dashboard/programs/program.service';
 import { DepartmentProgramsConfigService } from '../../etl-api/department-programs-config.service';
 import {
@@ -29,6 +30,7 @@ export class EditProgramComponent extends ProgramManagerBaseComponent implements
   public formsFilled = false;
 
   constructor(public patientService: PatientService,
+              public patientTransferService: PatientTransferService,
               public programService: ProgramService,
               public router: Router,
               public route: ActivatedRoute,
@@ -318,6 +320,7 @@ export class EditProgramComponent extends ProgramManagerBaseComponent implements
         this.theChangeComplete = true;
         this.showNoticeIfPossible();
         this.removeTransferInfo();
+        this.patientTransferService.clearTransferState();
       }, (err) => {
         console.log('failed to autenroll', err);
       });
@@ -341,6 +344,7 @@ export class EditProgramComponent extends ProgramManagerBaseComponent implements
         this.theChangeComplete = true;
         this.showNoticeIfPossible();
         this.removeTransferInfo();
+        this.patientTransferService.clearTransferState();
       }, (err) => {
         console.error('failed to autenroll', err);
       });


### PR DESCRIPTION
Previously, after effecting a transfer from either the program manager or a form, the transfer state from that process was being cached and being reused upon subsequent form refills. This commit introduces a fix that clears transfer state upon completion of each transfer.