### PR TITLE
POCONC-159: Fixes and improvements to the oncology snapshot display

### DIFF
--- a/src/app/patient-dashboard/oncology/program-snapshot/oncology-program-snapshot.component.html
+++ b/src/app/patient-dashboard/oncology/program-snapshot/oncology-program-snapshot.component.html
@@ -2,7 +2,7 @@
   <div *ngIf="hasError">
     <p class="alert alert-error text-error">Error generating Oncology program snapshot</p>
   </div>
-  <div *ngIf="!hasData && !hasError">
+  <div *ngIf="!hasData && !hasError && hasLoadedData">
     <p class="alert alert-warning">No patient data to generate Oncology program snapshot</p>
   </div>
   <div *ngIf="!hasError && hasData && !isIntegratedProgram">
@@ -49,7 +49,7 @@
       <hr>
     </ng-container>
   </div>
-  <div *ngIf="!hasData && !hasError">
+  <div *ngIf="!hasLoadedData && !hasError">
     <p>Loading patient data....</p>
   </div>
 </div>

--- a/src/app/patient-dashboard/oncology/program-snapshot/oncology-program-snapshot.component.ts
+++ b/src/app/patient-dashboard/oncology/program-snapshot/oncology-program-snapshot.component.ts
@@ -1,8 +1,12 @@
 import { Component, OnDestroy, OnInit, Input } from '@angular/core';
+
 import { Subscription } from 'rxjs';
+import { take } from 'rxjs/operators';
 import * as _ from 'lodash';
+
 import { Patient } from '../../../models/patient.model';
-import { OncologySummaryResourceService
+import {
+  OncologySummaryResourceService
 } from '../../../etl-api/oncology-summary-resource.service';
 
 @Component({
@@ -15,14 +19,16 @@ export class OncologyProgramSnapshotComponent implements OnInit, OnDestroy {
   @Input() public programUuid;
   public loadingSummary = false;
   public hasData = false;
+  public hasLoadedData = false;
   public isIntegratedProgram = false;
   public hasError = false;
   public subscription: Subscription;
   public patientUuid: any;
   public errors: any = [];
   public summaryData: any;
+  public oncologyScreeningAndDiagnosisProgramUuid = '37ff4124-91fd-49e6-8261-057ccfb4fcd0';
   constructor(
-    private oncolologySummary: OncologySummaryResourceService,
+    private oncologySummary: OncologySummaryResourceService,
     private integratedProgramSnapshot: OncologySummaryResourceService) {
   }
 
@@ -32,7 +38,7 @@ export class OncologyProgramSnapshotComponent implements OnInit, OnDestroy {
         this.hasError = true;
       } else {
         this.hasData = false;
-        if (this.programUuid === '37ff4124-91fd-49e6-8261-057ccfb4fcd0') {
+        if (this.programUuid === this.oncologyScreeningAndDiagnosisProgramUuid) {
           this.loadScreeningAndDiagnosisData(patientUuid);
         } else {
           this.loadOncologyDataSummary(patientUuid);
@@ -50,16 +56,20 @@ export class OncologyProgramSnapshotComponent implements OnInit, OnDestroy {
 
   public loadOncologyDataSummary(patientUuid) {
     if (this.programUuid && patientUuid) {
-      this.oncolologySummary.getOncologySummary('summary', patientUuid, this.programUuid).subscribe((summary) => {
-        this.summaryData = summary[0];
-        this.hasData =  true;
-        this.hasError = false;
+      this.loadingSummary = true;
+      this.oncologySummary.getOncologySummary('summary', patientUuid, this.programUuid).pipe(take(1)).subscribe((summary) => {
+        this.hasLoadedData = true;
         this.loadingSummary = false;
+        if (summary.length) {
+          this.summaryData = summary[0];
+          this.hasData = true;
+          this.hasError = false;
+        }
       }, (error) => {
         this.loadingSummary = false;
         this.hasData = false;
         this.hasError = true;
-        console.log(error);
+        console.error('Error fetching oncology summary: ', error);
         this.errors.push({
           id: 'summary',
           message: 'Error Fetching Summary'
@@ -69,20 +79,23 @@ export class OncologyProgramSnapshotComponent implements OnInit, OnDestroy {
   }
 
   private loadScreeningAndDiagnosisData(patientUuid: any) {
-    this.hasData =  true;
+    this.hasData = false;
     this.hasError = false;
     this.integratedProgramSnapshot.getIntegratedProgramSnapshot(patientUuid)
       .subscribe((screeningSummary) => {
-        this.isIntegratedProgram = true;
-        this.summaryData = screeningSummary;
-        this.hasData =  true;
-        this.hasError = false;
         this.loadingSummary = false;
+        this.hasLoadedData = true;
+        if (screeningSummary.length) {
+          this.summaryData = screeningSummary;
+          this.isIntegratedProgram = true;
+          this.hasData = true;
+          this.hasError = false;
+        }
       }, (error => {
         this.loadingSummary = false;
         this.hasData = false;
         this.hasError = true;
-        console.log(error);
+        console.error('Error fetching integrated screening summary: ', error);
         this.errors.push({
           id: 'summary',
           message: 'Error Fetching Summary'


### PR DESCRIPTION
This commit fixes the following issues with the oncology snapshot summary (#1080):

- The heading 'Last Encounter' being displayed when no summary data is available. Add a check to make sure an error message is displayed when no summary data is found for any oncology programs.
- Remove 'Loading patient data...' message after the patient's integrated screening data has been fetched.