### PR TITLE
POCONC-168: Remove male gender filter from cervical cancer screening report

### DIFF
--- a/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-indicators-patient-list/oncology-indicators-patient-list.component.ts
+++ b/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-indicators-patient-list/oncology-indicators-patient-list.component.ts
@@ -50,14 +50,14 @@ export class OncologySummaryIndicatorsPatientListComponent implements OnInit {
 
   public ngOnInit() {
     this.route.queryParams.subscribe((params: any) => {
-        if (params) {
-          this.getPatientList(params);
-          this.title = this.translateIndicator(params.indicators);
-          this.params = params;
-        }
-      }, (error) => {
-        console.error('Error', error);
-      });
+      if (params) {
+        this.getPatientList(params);
+        this.title = this.translateIndicator(params.indicators);
+        this.params = params;
+      }
+    }, (error) => {
+      console.error('Error', error);
+    });
   }
 
   public getPatientList(params) {
@@ -112,19 +112,18 @@ export class OncologySummaryIndicatorsPatientListComponent implements OnInit {
       return;
     }
     this.router.navigate(['/patient-dashboard/patient/' + patientUuid +
-    '/general/general/landing-page']);
+      '/general/general/landing-page']);
 
   }
 
   public translateIndicator(indicator: string) {
     const indicatorArray = indicator.toLowerCase().split('_');
     if (indicator === 'hiv_status') {
-        return indicatorArray[0].toUpperCase() + ' '
+      return indicatorArray[0].toUpperCase() + ' '
         + indicatorArray[1].charAt(0).toUpperCase() + indicatorArray[1].slice(1);
     } else {
-
       return indicatorArray.map((word) => {
-            return ((word.charAt(0).toUpperCase()) + word.slice(1));
+        return ((word.charAt(0).toUpperCase()) + word.slice(1));
       }).join(' ');
     }
   }

--- a/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-summary-filters/oncology-summary-filters.component.html
+++ b/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-summary-filters/oncology-summary-filters.component.html
@@ -15,7 +15,8 @@
                 [selectedIndicators]="selectedIndicators"
                 [selectedGender]="selectedGender"
                 [selectedPeriod]="period"
-                [reportName]="reportName" 
+                [reportName]="reportName"
+                [reportType]="reportType"
                 [parentIsBusy]="isLoadingReport" 
                 (generateReport)="generateReport()">
             </report-filters>

--- a/src/app/shared/report-filters/report-filters.component.ts
+++ b/src/app/shared/report-filters/report-filters.component.ts
@@ -1,4 +1,3 @@
-
 import { take } from 'rxjs/operators';
 import {
   Component, OnInit, EventEmitter, ElementRef, forwardRef,
@@ -44,6 +43,7 @@ import { SelectDepartmentService } from './../services/select-department.service
   ]
 })
 export class ReportFiltersComponent implements OnInit, ControlValueAccessor, AfterViewInit {
+  public cervicalScreeningReport = 'cervical-cancer-screening-numbers';
   @Input() public start: number;
   @Input() public end: number;
   @Input()
@@ -99,6 +99,7 @@ export class ReportFiltersComponent implements OnInit, ControlValueAccessor, Aft
   @Input()
   public disableGenerateButton = false;
   @Input() public enabledControls: string[];
+  @Input() public reportType: string;
   @Output()
   public locationChange = new EventEmitter<any>();
   public locations: any;
@@ -210,7 +211,14 @@ export class ReportFiltersComponent implements OnInit, ControlValueAccessor, Aft
   }
 
   public ngOnInit() {
+    if (this.reportType === this.cervicalScreeningReport) {
+      this.genderOptions = this.genderOptions.filter(option => {
+        return option.value === 'F' && option.label === 'F';
+      });
+    }
+
     this.renderFilterControls();
+
     if (this.start && this.end) {
       this.onAgeChangeFinish.emit({ ageFrom: this.start, ageTo: this.end });
     }


### PR DESCRIPTION
This PR removes the 'M' (Male) option from the gender filter on the cervical cancer screening report as male clients obviously shouldn't be eligible for that type of screening.