### PR TITLE
POCONC-172: Add columns to breast & cervical patient lists for abnormal findings

### DIFF
--- a/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-indicators-patient-list/oncology-indicators-patient-list.component.spec.ts
+++ b/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-indicators-patient-list/oncology-indicators-patient-list.component.spec.ts
@@ -191,13 +191,20 @@ describe('OncologySummaryIndicatorsPatientListComponent', () => {
     fixture.detectChanges();
     expect(component.generateDynamicPatientListCols).toHaveBeenCalledTimes(1);
     expect(component.oncologySummaryColdef.length).toEqual(10);
-    expect(component.oncologySummaryColdef).toContain({ headerName: '#', field: 'no' });
+    expect(component.oncologySummaryColdef).toContain({ headerName: '#', field: 'no', width: 50, pinned: true });
     expect(component.oncologySummaryColdef).toContain({ headerName: 'Patient Uuid', field: 'patient_uuid', hide: true });
-    expect(component.oncologySummaryColdef).toContain({ headerName: 'Encounter Date', field: 'encounter_datetime', hide: false });
+    expect(component.oncologySummaryColdef).toContain(
+      {
+        headerName: 'Encounter Date',
+        field: 'encounter_datetime',
+        pinned: true,
+        width: 100
+      }
+    );
     expect(component.oncologySummaryColdef).toContain({ headerName: 'Location Name', field: 'location_name', hide: false });
     expect(component.oncologySummaryColdef).toContain({ headerName: 'Identifiers', field: 'identifiers', hide: false });
-    expect(component.oncologySummaryColdef).toContain({ headerName: 'Person Name', field: 'person_name', hide: false });
     expect(component.oncologySummaryColdef).toContain({ headerName: 'Gender', field: 'gender', hide: false });
+    expect(component.oncologySummaryColdef).toContain({ headerName: 'Person Name', field: 'person_name', pinned: true, width: 250 });
     expect(component.oncologySummaryColdef).toContain({ headerName: 'Age', field: 'age', hide: false });
     expect(component.oncologySummaryColdef).toContain({ headerName: 'Phone Number', field: 'phone_number', hide: false });
     expect(component.oncologySummaryColdef).toContain({ headerName: 'Type Of Abnormality', field: 'type_of_abnormality', hide: false });

--- a/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-indicators-patient-list/oncology-indicators-patient-list.component.ts
+++ b/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-indicators-patient-list/oncology-indicators-patient-list.component.ts
@@ -77,7 +77,9 @@ export class OncologySummaryIndicatorsPatientListComponent implements OnInit {
     const columns = [
       {
         headerName: '#',
-        field: 'no'
+        field: 'no',
+        width: 50,
+        pinned: true
       },
       {
         headerName: 'Patient Uuid',
@@ -88,13 +90,27 @@ export class OncologySummaryIndicatorsPatientListComponent implements OnInit {
 
     _.each(patientListCols, (cols: any) => {
       if (cols === 'patient_uuid') {
-
-      } else if (cols === 'encounter_datetime') {
+        return '';
+      } else if (cols === 'person_name') {
         columns.push({
-          headerName: 'Encounter Date',
-          field: cols,
+          headerName: 'Person Name',
+          field: 'person_name',
+          pinned: true,
+          width: 250
+        });
+      } else if (cols === 'via_rtc_date') {
+        columns.push({
+          headerName: 'VIA RTC date',
+          field: 'via_rtc_date',
           hide: false
         });
+      } else if (cols === 'encounter_datetime') {
+          columns.push({
+            headerName: 'Encounter Date',
+            field: 'encounter_datetime',
+            pinned: true,
+            width: 100
+          });
       } else {
         columns.push({
           headerName: this.translateIndicator(cols),

--- a/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-pdf-reports.json
+++ b/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-pdf-reports.json
@@ -1,7 +1,9 @@
 {
-  "reports": [{
+  "reports": [
+    {
       "report_type": "breast-cancer-screening-numbers",
-      "sections": [{
+      "sections": [
+        {
           "section": "total_breast_screened",
           "report_indicators": [
             "total_breast_screened"
@@ -20,32 +22,33 @@
           ]
         },
         {
-          "section": "normal_breast_screening_findings",
+          "section": "normal_findings",
           "report_indicators": [
-            "normal_breast_screening_findings",
-            "normal_breast_screening_findings_below_30yrs",
-            "normal_breast_screening_findings_30_to_40yrs",
-            "normal_breast_screening_findings_41_to_50yrs",
-            "normal_breast_screening_findings_51_to_69yrs",
-            "normal_breast_screening_findings_above_70yrs"
+            "normal_findings",
+            "normal_below_30yrs",
+            "normal_30_to_40yrs",
+            "normal_41_to_50yrs",
+            "normal_51_to_69yrs",
+            "normal_above_70yrs"
           ]
         },
         {
-          "section": "abnormal_breast_screening_findings",
+          "section": "abnormal_findings",
           "report_indicators": [
-            "abnormal_breast_screening_findings",
-            "abnormal_breast_screening_findings_below_30yrs",
-            "abnormal_breast_screening_findings_30_to_40yrs",
-            "abnormal_breast_screening_findings_41_to_50yrs",
-            "abnormal_breast_screening_findings_51_to_69yrs",
-            "abnormal_breast_screening_findings_above_70yrs"
+            "abnormal_findings",
+            "abnormal_below_30yrs",
+            "abnormal_30_to_40yrs",
+            "abnormal_41_to_50yrs",
+            "abnormal_51_to_69yrs",
+            "abnormal_above_70yrs"
           ]
         }
       ]
     },
     {
       "report_type": "cervical-cancer-screening-numbers",
-      "sections": [{
+      "sections": [
+        {
           "section": "total_cervical_screened",
           "report_indicators": [
             "total_cervical_screened"
@@ -64,47 +67,49 @@
           ]
         },
         {
-          "section": "normal_cervical_screening",
+          "section": "normal_findings",
           "report_indicators": [
-            "normal_cervical_screening",
-            "normal_cervical_screening_below_30yrs",
-            "normal_cervical_screening_30_to_40yrs",
-            "normal_cervical_screening_41_to_50yrs",
-            "normal_cervical_screening_51_to_69yrs",
-            "normal_cervical_screening_above_70yrs"
+            "normal_findings",
+            "normal_below_30yrs",
+            "normal_30_to_40yrs",
+            "normal_41_to_50yrs",
+            "normal_51_to_69yrs",
+            "normal_above_70yrs"
           ]
         },
         {
-          "section": "abnormal_cervical_screening",
+          "section": "abnormal_findings",
           "report_indicators": [
-            "abnormal_cervical_screening",
-            "abnormal_cervical_screening_below_30yrs",
-            "abnormal_cervical_screening_30_to_40yrs",
-            "abnormal_cervical_screening_41_to_50yrs",
-            "abnormal_cervical_screening_51_to_69yrs",
-            "abnormal_cervical_screening_above_70yrs"
+            "abnormal_findings",
+            "abnormal_below_30yrs",
+            "abnormal_30_to_40yrs",
+            "abnormal_41_to_50yrs",
+            "abnormal_51_to_69yrs",
+            "abnormal_above_70yrs"
           ]
         }
       ]
     },
     {
       "report_type": "combined-breast-cervical-cancer-screening-numbers",
-      "sections": [{
-        "section": "total_screens",
-        "report_indicators": [
-          "total_screens",
-          "total_breast_screened",
-          "total_cervical_screened",
-          "total_breast_and_cervical_screened"
-        ]
-      }]
+      "sections": [
+        {
+          "section": "total_screens",
+          "report_indicators": [
+            "total_screens",
+            "total_breast_screened",
+            "total_cervical_screened",
+            "total_breast_and_cervical_screened"
+          ]
+        }
+      ]
     },
     {
       "report_type": "lung-cancer-screening-numbers",
-      "sections":[
+      "sections": [
         {
           "section": "total_lung_screened",
-          "report_indicators":[
+          "report_indicators": [
             "total_lung_screened",
             "walk_in",
             "referred_from_clinic",
@@ -132,33 +137,34 @@
       ]
     },
     {
-        "report_type": "lung-cancer-treatment-numbers",
-        "sections": [{
-                "section": "enrolled_patients",
-                "report_indicators": [
-                    "enrolled_patients",
-                    "active_patients",
-                    "deceased",
-                    "small_cell_lung_cancer",
-                    "non_small_cell_lung_cancer",
-                    "adenocarcinoma",
-                    "epidermoid_carcinoma",
-                    "large_cell_carcinoma",
-                    "mixed_squamous",
-                    "lost_to_follow_up",
-                    "stage_one",
-                    "stage_two",
-                    "stage_three",
-                    "stage_four",
-                    "limited_stage",
-                    "extensive_stage",
-                    "for_staging",
-                    "chemotherapy",
-                    "radiotherapy",
-                    "surgery"
-                ]
-            }
-        ]
+      "report_type": "lung-cancer-treatment-numbers",
+      "sections": [
+        {
+          "section": "enrolled_patients",
+          "report_indicators": [
+            "enrolled_patients",
+            "active_patients",
+            "deceased",
+            "small_cell_lung_cancer",
+            "non_small_cell_lung_cancer",
+            "adenocarcinoma",
+            "epidermoid_carcinoma",
+            "large_cell_carcinoma",
+            "mixed_squamous",
+            "lost_to_follow_up",
+            "stage_one",
+            "stage_two",
+            "stage_three",
+            "stage_four",
+            "limited_stage",
+            "extensive_stage",
+            "for_staging",
+            "chemotherapy",
+            "radiotherapy",
+            "surgery"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-report-pdf-view/oncology-report-pdf.service.spec.ts
+++ b/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-report-pdf-view/oncology-report-pdf.service.spec.ts
@@ -8,42 +8,42 @@ const mockParams = {
   data: [
     {
       'abnormal_breast_call_rate%': 2.38,
-      'abnormal_breast_screening_findings': 1,
-      'abnormal_breast_screening_findings_30_to_40_yrs': 0,
-      'abnormal_breast_screening_findings_41_to_50_yrs': 0,
-      'abnormal_breast_screening_findings_51_to_69_yrs': 1,
-      'abnormal_breast_screening_findings_above_70_yrs': 0,
-      'abnormal_breast_screening_findings_below_30_yrs': 0,
+      'abnormal_findings': 1,
+      'abnormal_30_to_40_yrs': 0,
+      'abnormal_41_to_50_yrs': 0,
+      'abnormal_51_to_69_yrs': 1,
+      'abnormal_above_70_yrs': 0,
+      'abnormal_below_30_yrs': 0,
       'encounter_datetime': '02-2019',
       'location_name': 'Turbo',
       'location_uuid': '08feb2dc-1352-11df-a1f1-0026b9348838',
       'normal_breast_call_rate%': 97.62,
-      'normal_breast_screening_findings': 41,
-      'normal_breast_screening_findings_30_to_40yrs': 13,
-      'normal_breast_screening_findings_41_to_50yrs': 9,
-      'normal_breast_screening_findings_51_to_69yrs': 9,
-      'normal_breast_screening_findings_above_70yrs': 2,
-      'normal_breast_screening_findings_below_30yrs': 7,
+      'normal_findings': 41,
+      'normal_below_30yrs': 7,
+      'normal_30_to_40yrs': 13,
+      'normal_41_to_50yrs': 9,
+      'normal_51_to_69yrs': 9,
+      'normal_above_70yrs': 2,
       'total_breast_screened': 42
     },
     {
       'abnormal_breast_call_rate%': 2.56,
-      'abnormal_breast_screening_findings': 2,
-      'abnormal_breast_screening_findings_30_to_40_yrs': 0,
-      'abnormal_breast_screening_findings_41_to_50_yrs': 0,
-      'abnormal_breast_screening_findings_51_to_69_yrs': 0,
-      'abnormal_breast_screening_findings_above_70_yrs': 0,
-      'abnormal_breast_screening_findings_below_30_yrs': 2,
+      'abnormal_findings': 2,
+      'abnormal_below_30_yrs': 2,
+      'abnormal_30_to_40_yrs': 0,
+      'abnormal_41_to_50_yrs': 0,
+      'abnormal_51_to_69_yrs': 0,
+      'abnormal_above_70_yrs': 0,
       'encounter_datetime': '01-2019',
       'location_name': 'Chulaimbo',
       'location_uuid': '08feb7b4-1352-11df-a1f1-0026b9348838',
       'normal_breast_call_rate%': 97.44,
-      'normal_breast_screening_findings': 76,
-      'normal_breast_screening_findings_30_to_40yrs': 24,
-      'normal_breast_screening_findings_41_to_50yrs': 14,
-      'normal_breast_screening_findings_51_to_69yrs': 15,
-      'normal_breast_screening_findings_above_70yrs': 1,
-      'normal_breast_screening_findings_below_30yrs': 19,
+      'normal_findings': 76,
+      'normal_below_30yrs': 19,
+      'normal_30_to_40yrs': 24,
+      'normal_41_to_50yrs': 14,
+      'normal_51_to_69yrs': 15,
+      'normal_above_70yrs': 1,
       'total_breast_screened': 78
     }
   ],
@@ -76,28 +76,29 @@ describe('OncologyReportPdfService: ', () => {
       { section: 'total_breast_screened', report_indicators: ['total_breast_screened'] },
       { section: 'normal_breast_call_rate%', report_indicators: ['normal_breast_call_rate%'] },
       { section: 'abnormal_breast_call_rate%', report_indicators: ['abnormal_breast_call_rate%'] },
-      { section: 'normal_breast_screening_findings',
+      {
+        section: 'normal_findings',
         report_indicators: [
-          'normal_breast_screening_findings',
-          'normal_breast_screening_findings_below_30yrs',
-          'normal_breast_screening_findings_30_to_40yrs',
-          'normal_breast_screening_findings_41_to_50yrs',
-          'normal_breast_screening_findings_51_to_69yrs',
-          'normal_breast_screening_findings_above_70yrs'
+          'normal_findings',
+          'normal_below_30yrs',
+          'normal_30_to_40yrs',
+          'normal_41_to_50yrs',
+          'normal_51_to_69yrs',
+          'normal_above_70yrs'
         ]
       },
-      { section: 'abnormal_breast_screening_findings',
+      {
+        section: 'abnormal_findings',
         report_indicators: [
-          'abnormal_breast_screening_findings',
-          'abnormal_breast_screening_findings_below_30yrs',
-          'abnormal_breast_screening_findings_30_to_40yrs',
-          'abnormal_breast_screening_findings_41_to_50yrs',
-          'abnormal_breast_screening_findings_51_to_69yrs',
-          'abnormal_breast_screening_findings_above_70yrs'
+          'abnormal_findings',
+          'abnormal_below_30yrs',
+          'abnormal_30_to_40yrs',
+          'abnormal_41_to_50yrs',
+          'abnormal_51_to_69yrs',
+          'abnormal_above_70yrs'
         ]
       }
     ];
-
   });
 
   it('should be created', () => {
@@ -121,7 +122,7 @@ describe('OncologyReportPdfService: ', () => {
       (err) => {
         console.error('Err: ', err);
       });
-      done();
+    done();
   });
 
   it('constructAggregatePdfStructure returns the observable result of creating an aggregated PDF document', () => {
@@ -147,14 +148,14 @@ describe('OncologyReportPdfService: ', () => {
         ]
       )
     );
-    expect(result[0][0][1].table.body[0][0].text).toEqual('Normal breast screening findings');
+    expect(result[0][0][1].table.body[0][0].text).toEqual('Normal findings');
     expect(result[0][0][1].table.body[0][1].text).toEqual(117);
     expect((result[0][0][1].table.body).length).toEqual(6);
-    expect(result[0][0][1].table.body[1]).toContain('Normal breast screening findings below 30yrs');
-    expect(result[0][0][1].table.body[2]).toContain('Normal breast screening findings 30 to 40yrs');
-    expect(result[0][0][1].table.body[3]).toContain('Normal breast screening findings 41 to 50yrs');
-    expect(result[0][0][1].table.body[4]).toContain('Normal breast screening findings 51 to 69yrs');
-    expect(result[0][0][1].table.body[5]).toContain('Normal breast screening findings above 70yrs');
+    expect(result[0][0][1].table.body[1]).toContain('Normal below 30yrs');
+    expect(result[0][0][1].table.body[2]).toContain('Normal 30 to 40yrs');
+    expect(result[0][0][1].table.body[3]).toContain('Normal 41 to 50yrs');
+    expect(result[0][0][1].table.body[4]).toContain('Normal 51 to 69yrs');
+    expect(result[0][0][1].table.body[5]).toContain('Normal above 70yrs');
   });
 
   it('constructBodySection returns an array containing the sections that make up the body of the PDF document', () => {
@@ -167,18 +168,19 @@ describe('OncologyReportPdfService: ', () => {
     expect(result[1][0].table.body[0][1].text).toEqual(97.62);
     expect(result[2][0].table.body[0][0].text).toEqual('Abnormal breast call rate%');
     expect(result[2][0].table.body[0][1].text).toEqual(2.38);
-    expect(result[3][0].table.body[0][0].text).toEqual('Normal breast screening findings');
+    expect(result[3][0].table.body[0][0].text).toEqual('Normal findings');
     expect(result[3][0].table.body[0][1].text).toEqual(41);
-    expect(result[3][0].table.body[1][0]).toEqual('Normal breast screening findings 30 to 40yrs');
-    expect(result[3][0].table.body[1][1]).toEqual(13);
-    expect(result[3][0].table.body[2][0]).toEqual('Normal breast screening findings 41 to 50yrs');
-    expect(result[3][0].table.body[2][1]).toEqual(9);
-    expect(result[3][0].table.body[3][0]).toEqual('Normal breast screening findings 51 to 69yrs');
+    expect(result[3][0].table.body[1][0]).toEqual('Normal below 30yrs');
+    expect(result[3][0].table.body[1][1]).toEqual(7);
+    expect(result[3][0].table.body[2][0]).toEqual('Normal 30 to 40yrs');
+    expect(result[3][0].table.body[2][1]).toEqual(13);
+    expect(result[3][0].table.body[3][0]).toEqual('Normal 41 to 50yrs');
     expect(result[3][0].table.body[3][1]).toEqual(9);
-    expect(result[3][0].table.body[4][0]).toEqual('Normal breast screening findings above 70yrs');
-    expect(result[3][0].table.body[4][1]).toEqual(2);
-    expect(result[3][0].table.body[5][0]).toEqual('Normal breast screening findings below 30yrs');
-    expect(result[3][0].table.body[5][1]).toEqual(7);
+    expect(result[3][0].table.body[4][0]).toEqual('Normal 51 to 69yrs');
+    expect(result[3][0].table.body[4][1]).toEqual(9);
+    expect(result[3][0].table.body[5][0]).toEqual('Normal above 70yrs');
+    expect(result[3][0].table.body[5][1]).toEqual(2);
+
   });
 
   it('constructPdfSections returns an array containing the headers that make up the sections of the PDF document', () => {
@@ -234,18 +236,19 @@ describe('OncologyReportPdfService: ', () => {
     expect(result[1].table.body[0][1].text).toEqual(97.62);
     expect(result[2].table.body[0][0].text).toEqual('Abnormal breast call rate%');
     expect(result[2].table.body[0][1].text).toEqual(2.38);
-    expect(result[3].table.body[0][0].text).toEqual('Normal breast screening findings');
+    expect(result[3].table.body[0][0].text).toEqual('Normal findings');
     expect(result[3].table.body[0][1].text).toEqual(41);
-    expect(result[3].table.body[1][0]).toEqual('Normal breast screening findings 30 to 40yrs');
-    expect(result[3].table.body[1][1]).toEqual(13);
-    expect(result[3].table.body[2][0]).toEqual('Normal breast screening findings 41 to 50yrs');
-    expect(result[3].table.body[2][1]).toEqual(9);
-    expect(result[3].table.body[3][0]).toEqual('Normal breast screening findings 51 to 69yrs');
+    expect(result[3].table.body[1][0]).toEqual('Normal below 30yrs');
+    expect(result[3].table.body[1][1]).toEqual(7);
+    expect(result[3].table.body[2][0]).toEqual('Normal 30 to 40yrs');
+    expect(result[3].table.body[2][1]).toEqual(13);
+    expect(result[3].table.body[3][0]).toEqual('Normal 41 to 50yrs');
     expect(result[3].table.body[3][1]).toEqual(9);
-    expect(result[3].table.body[4][0]).toEqual('Normal breast screening findings above 70yrs');
-    expect(result[3].table.body[4][1]).toEqual(2);
-    expect(result[3].table.body[5][0]).toEqual('Normal breast screening findings below 30yrs');
-    expect(result[3].table.body[5][1]).toEqual(7);
+    expect(result[3].table.body[4][0]).toEqual('Normal 51 to 69yrs');
+    expect(result[3].table.body[4][1]).toEqual(9);
+    expect(result[3].table.body[5][0]).toEqual('Normal above 70yrs');
+    expect(result[3].table.body[5][1]).toEqual(2);
+
   });
 
   it('constructTableSection returns an array of rows that make up the table layout', () => {
@@ -262,123 +265,123 @@ describe('OncologyReportPdfService: ', () => {
     expect(result[1][1].text).toEqual(97.62);
     expect(result[2][0].text).toEqual('Abnormal breast call rate%');
     expect(result[2][1].text).toEqual(2.38);
-    expect(result[3][0].text).toEqual('Normal breast screening findings');
+    expect(result[3][0].text).toEqual('Normal findings');
     expect(result[3][1].text).toEqual(41);
-    expect(result[4][0]).toEqual('Normal breast screening findings 30 to 40yrs');
-    expect(result[4][1]).toEqual(13);
-    expect(result[5][0]).toEqual('Normal breast screening findings 41 to 50yrs');
-    expect(result[5][1]).toEqual(9);
-    expect(result[6][0]).toEqual('Normal breast screening findings 51 to 69yrs');
+    expect(result[4][0]).toEqual('Normal below 30yrs');
+    expect(result[4][1]).toEqual(7);
+    expect(result[5][0]).toEqual('Normal 30 to 40yrs');
+    expect(result[5][1]).toEqual(13);
+    expect(result[6][0]).toEqual('Normal 41 to 50yrs');
     expect(result[6][1]).toEqual(9);
-    expect(result[7][0]).toEqual('Normal breast screening findings above 70yrs');
-    expect(result[7][1]).toEqual(2);
-    expect(result[8][0]).toEqual('Normal breast screening findings below 30yrs');
-    expect(result[8][1]).toEqual(7);
+    expect(result[7][0]).toEqual('Normal 51 to 69yrs');
+    expect(result[7][1]).toEqual(9);
+    expect(result[8][0]).toEqual('Normal above 70yrs');
+    expect(result[8][1]).toEqual(2);
   });
 
   it('generatePdf returns the observable result of creating the PDF document or an error when passed the wrong properties',
     (done: DoneFn) => {
-    service.generatePdf(mockParams.data, mockParams.params, mockParams.title)
-      .subscribe((pdfStructure) => {
-        expect(pdfStructure).toBeDefined();
-        expect(pdfStructure.pdfSrc).toBeDefined();
-        expect(pdfStructure.pdfProxy).toBeDefined();
-        expect(pdfStructure.pdfDefinition).toBeDefined();
-        // pdfSrc
-        expect(pdfStructure.pdfSrc).toEqual(jasmine.stringMatching(/blob\:http\:\/\/localhost\:9876/));
-        // pdfProxy
-        expect(pdfStructure.pdfProxy.docDefinition).toEqual(
-          jasmine.objectContaining(
-            {
-              pageSize: 'LETTER',
-              pageMargins: 42
-            }
-          )
-        );
-        expect(pdfStructure.pdfProxy.docDefinition.content.length).toEqual(2);
-        expect(pdfStructure.pdfProxy.docDefinition.content[0].stack[0]).toEqual(
-          jasmine.objectContaining(
-            {
-              alignment: 'center',
-              image: '$$pdfmake$$1'
-            }
-          )
-        );
-        expect(pdfStructure.pdfProxy.docDefinition.content[0].stack[1]).toEqual(
-          jasmine.objectContaining(
-            {
-              alignment: 'center',
-              text: 'B1 Breast Cancer Screening Numbers Report',
-              style: 'mainHeader'
-            }
-          )
-        );
-        expect(pdfStructure.pdfProxy.docDefinition.content[1].stack.length).toEqual(3);
-        expect(pdfStructure.pdfProxy.docDefinition.content[1].stack[1].stack[0].table.body[0][0]).toEqual(
-          jasmine.objectContaining(
-            {
-              text: 'Facility Name: Turbo',
-              style: 'headerStyle'
-            }
-          )
-        );
-        expect(pdfStructure.pdfProxy.docDefinition.content[1].stack[1].stack[0].table.body[0][1]).toEqual(
-          jasmine.objectContaining(
-            {
-              text: 'Date: 02-2019',
-              style: 'headerStyle'
-            }
-          )
-        );
-        expect(pdfStructure.pdfProxy.docDefinition.content[1].stack[1].stack[1].stack[0].stack[0]).toEqual(
-          jasmine.objectContaining(
-            {
-              headerRows: 1,
-              style: 'defaultTable'
-            }
-          )
-        );
-        expect(pdfStructure.pdfProxy.docDefinition.content[1].stack[1].stack[1].stack[0].stack[0].table.body[0][0]).toEqual(
-          jasmine.objectContaining(
-            {
-              text: 'Total breast screened',
-              style: 'headerstyle'
-            }
-          )
-        );
-        expect(pdfStructure.pdfProxy.docDefinition.content[1].stack[1].stack[1].stack[0].stack[0].table.body[0][1]).toEqual(
-          jasmine.objectContaining(
-            {
-              text: 42,
-              style: 'headerstyle'
-            }
-          )
-        );
-        // pdfDefinition
-        expect(pdfStructure.pdfDefinition.content.length).toEqual(2);
-        expect(pdfStructure.pdfDefinition.footer.stack[0].text).toEqual(jasmine.stringMatching('Generated On:'));
-        expect(pdfStructure.pdfDefinition.footer.stack[0].style).toEqual(
-          jasmine.objectContaining(
-            {
-              alignment: 'center',
-              fontSize: 8
-            }
-          )
-        );
-        done();
-      }, (err) => {
-        console.error('Err: ', err);
-      });
-  });
+      service.generatePdf(mockParams.data, mockParams.params, mockParams.title)
+        .subscribe((pdfStructure) => {
+          expect(pdfStructure).toBeDefined();
+          expect(pdfStructure.pdfSrc).toBeDefined();
+          expect(pdfStructure.pdfProxy).toBeDefined();
+          expect(pdfStructure.pdfDefinition).toBeDefined();
+          // pdfSrc
+          expect(pdfStructure.pdfSrc).toEqual(jasmine.stringMatching(/blob\:http\:\/\/localhost\:9876/));
+          // pdfProxy
+          expect(pdfStructure.pdfProxy.docDefinition).toEqual(
+            jasmine.objectContaining(
+              {
+                pageSize: 'LETTER',
+                pageMargins: 42
+              }
+            )
+          );
+          expect(pdfStructure.pdfProxy.docDefinition.content.length).toEqual(2);
+          expect(pdfStructure.pdfProxy.docDefinition.content[0].stack[0]).toEqual(
+            jasmine.objectContaining(
+              {
+                alignment: 'center',
+                image: '$$pdfmake$$1'
+              }
+            )
+          );
+          expect(pdfStructure.pdfProxy.docDefinition.content[0].stack[1]).toEqual(
+            jasmine.objectContaining(
+              {
+                alignment: 'center',
+                text: 'B1 Breast Cancer Screening Numbers Report',
+                style: 'mainHeader'
+              }
+            )
+          );
+          expect(pdfStructure.pdfProxy.docDefinition.content[1].stack.length).toEqual(3);
+          expect(pdfStructure.pdfProxy.docDefinition.content[1].stack[1].stack[0].table.body[0][0]).toEqual(
+            jasmine.objectContaining(
+              {
+                text: 'Facility Name: Turbo',
+                style: 'headerStyle'
+              }
+            )
+          );
+          expect(pdfStructure.pdfProxy.docDefinition.content[1].stack[1].stack[0].table.body[0][1]).toEqual(
+            jasmine.objectContaining(
+              {
+                text: 'Date: 02-2019',
+                style: 'headerStyle'
+              }
+            )
+          );
+          expect(pdfStructure.pdfProxy.docDefinition.content[1].stack[1].stack[1].stack[0].stack[0]).toEqual(
+            jasmine.objectContaining(
+              {
+                headerRows: 1,
+                style: 'defaultTable'
+              }
+            )
+          );
+          expect(pdfStructure.pdfProxy.docDefinition.content[1].stack[1].stack[1].stack[0].stack[0].table.body[0][0]).toEqual(
+            jasmine.objectContaining(
+              {
+                text: 'Total breast screened',
+                style: 'headerstyle'
+              }
+            )
+          );
+          expect(pdfStructure.pdfProxy.docDefinition.content[1].stack[1].stack[1].stack[0].stack[0].table.body[0][1]).toEqual(
+            jasmine.objectContaining(
+              {
+                text: 42,
+                style: 'headerstyle'
+              }
+            )
+          );
+          // pdfDefinition
+          expect(pdfStructure.pdfDefinition.content.length).toEqual(2);
+          expect(pdfStructure.pdfDefinition.footer.stack[0].text).toEqual(jasmine.stringMatching('Generated On:'));
+          expect(pdfStructure.pdfDefinition.footer.stack[0].style).toEqual(
+            jasmine.objectContaining(
+              {
+                alignment: 'center',
+                fontSize: 8
+              }
+            )
+          );
+          done();
+        }, (err) => {
+          console.error('Err: ', err);
+        });
+    });
 
-  it('format indicators returns strips the given indicator of underscores and transforms it into sentence case', () => {
+  it('format indicators strips the given indicator of underscores and transforms it into sentence case', () => {
     const testIndicators = [
-      'abnormal_breast_screening_findings',
-      'abnormal_breast_screening_findings_below_30yrs'
+      'abnormal_findings',
+      'abnormal_below_30yrs'
     ];
 
     const processedIndicators = testIndicators.map(indicator => service.formatReportIndicators(indicator));
-    expect(processedIndicators[0]).toEqual('Abnormal breast screening findings');
-    expect(processedIndicators[1]).toEqual('Abnormal breast screening findings below 30yrs');
+    expect(processedIndicators[0]).toEqual('Abnormal findings');
+    expect(processedIndicators[1]).toEqual('Abnormal below 30yrs');
   });
 });

--- a/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-report-pdf-view/oncology-report-pdf.service.ts
+++ b/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-report-pdf-view/oncology-report-pdf.service.ts
@@ -17,7 +17,7 @@ import * as OncologyReportConfig from '../oncology-pdf-reports.json';
   providedIn: 'root'
 })
 export class OncologyReportPdfService {
-  public  data: object = null;
+  public data: object = null;
 
   public constructor() { }
 
@@ -255,7 +255,7 @@ export class OncologyReportPdfService {
     return sectionsArray;
   }
 
-  private  styleAggregateTable(data: Array<Array<any>>) {
+  private styleAggregateTable(data: Array<Array<any>>) {
     return [
       {
         style: 'defaultTable',
@@ -464,11 +464,11 @@ export class OncologyReportPdfService {
 
   }
 
-  private  _formatDate(date: Date) {
+  private _formatDate(date: Date) {
     return _.isNull(date) ? 'None' : Moment(date).format('DD-MM-YYYY');
   }
 
-  private  getAppVersion(): string {
+  private getAppVersion(): string {
     try {
       return VERSION.version + VERSION.hash;
     } catch (e) {
@@ -476,7 +476,7 @@ export class OncologyReportPdfService {
     }
   }
 
-  private  base64ToUint8Array(base64: any): Uint8Array {
+  private base64ToUint8Array(base64: any): Uint8Array {
     const raw = atob(base64);
     const uint8Array = new Uint8Array(raw.length);
     for (let i = 0; i < raw.length; i++) {
@@ -485,7 +485,7 @@ export class OncologyReportPdfService {
     return uint8Array;
   }
 
-  private  getLogo(url: string, callback: any): void {
+  private getLogo(url: string, callback: any): void {
     const image: any = new Image();
     image.onload = function () {
       const canvas: any = document.createElement('canvas');

--- a/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-summary-indicators-table/oncology-summary-indicators-table.component.ts
+++ b/src/app/data-analytics-dashboard/oncology/oncology-reports/oncology-summary-indicators-table/oncology-summary-indicators-table.component.ts
@@ -6,267 +6,253 @@ import * as moment from 'moment';
 import { AgGridNg2 } from 'ag-grid-angular';
 
 @Component({
-    selector: 'oncology-summary-indicators-table',
-    templateUrl: 'oncology-summary-indicators-table.component.html',
-    styleUrls: ['./oncology-summary-indicators-table.component.css']
+  selector: 'oncology-summary-indicators-table',
+  templateUrl: 'oncology-summary-indicators-table.component.html',
+  styleUrls: ['./oncology-summary-indicators-table.component.css']
 })
 
 export class OncologySummaryIndicatorsTableComponent implements OnInit, OnChanges {
-public startDate: any;
-    public endDate: any;
-    public locationUuids: any;
-    public gridOptions: any = {
-        enableColResize: true,
-        enableSorting: true,
-        enableFilter: true,
-        showToolPanel: false,
-        onGridSizeChanged: () => {},
-        onGridReady: () => {},
-        autoGroupColumnDef: {
-            headerName: 'Location'
-        }
-    };
-    @Input() public monthlySummary: Array<any> = [];
-    @Input() public params: any;
-    @Input() public indicator = '';
-
-    public columns: any = [];
-    public data: any = [];
-    public mockResults: any = [];
-    public oncologySummaryColdef: any = [];
-    public pinnedBottomRowData: any = [];
-
-    @ViewChild('agGrid')
-    public agGrid: AgGridNg2;
-    constructor(
-        private router: Router,
-        private route: ActivatedRoute) { }
-
-    public ngOnInit() {}
-
-    public ngOnChanges(changes: SimpleChanges) {
-        if (changes.monthlySummary) {
-            this.processSummaryData(this.monthlySummary);
-        }
+  public startDate: any;
+  public endDate: any;
+  public locationUuids: any;
+  public gridOptions: any = {
+    enableColResize: true,
+    enableSorting: true,
+    enableFilter: true,
+    showToolPanel: false,
+    onGridSizeChanged: () => { },
+    onGridReady: () => { },
+    autoGroupColumnDef: {
+      headerName: 'Location',
+      pinned: true
     }
-    public onCellClicked(event) {
-        this.goToPatientList(event);
+  };
+  @Input() public monthlySummary: Array<any> = [];
+  @Input() public params: any;
+  @Input() public indicator = '';
+
+  public columns: any = [];
+  public data: any = [];
+  public mockResults: any = [];
+  public oncologySummaryColdef: any = [];
+  public pinnedBottomRowData: any = [];
+
+  @ViewChild('agGrid')
+  public agGrid: AgGridNg2;
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute) { }
+
+  public ngOnInit() { }
+
+  public ngOnChanges(changes: SimpleChanges) {
+    if (changes.monthlySummary) {
+      this.processSummaryData(this.monthlySummary);
     }
-    public processSummaryData(results) {
-      this.data = results;
-      const firstRow = results[0];
-      this.generateColumns(firstRow);
-      this.setRowData(results);
+  }
 
+  public onCellClicked(event) {
+    if (event.value === 0 || _.isNull(event.value)) {
+      return;
     }
-    public generateColumns(firstRow) {
-        const cols: any = [
-            {
-                headerName: 'location_uuid',
-                field : 'location_uuid',
-                hide: true
-            },
-           {
-            headerName: 'Period',
-            field : 'encounter_datetime'
-           },
-           {
-            headerName: 'Location',
-            field : 'location_name',
-            width: 250,
-            rowGroup: true,
-            hide: true
-           }
-        ];
+    this.goToPatientList(event);
+  }
 
-        _.each(firstRow, (data, index) => {
-            if ( index === 'encounter_datetime' || index === 'location_uuid' ||
-            index === 'location_name' || index === 'location_id') {
+  public processSummaryData(results) {
+    this.data = results;
+    const firstRow = results[0];
+    this.generateColumns(firstRow);
+    this.setRowData(results);
+  }
 
-            } else {
+  public generateColumns(firstRow) {
+    const cols: any = [
+      {
+        headerName: 'location_uuid',
+        field: 'location_uuid',
+        hide: true
+      },
+      {
+        headerName: 'Period',
+        field: 'encounter_datetime',
+        pinned: true,
+        width: 100
+      },
+      {
+        headerName: 'Location',
+        field: 'location_name',
+        width: 250,
+        rowGroup: true,
+        hide: true
+      }
+    ];
 
-                cols.push(
-                    {
-                        'headerName': this.translateIndicator(index),
-                        'field': index,
-                         cellRenderer: (column) => {
-                            if (typeof column.value === 'undefined') {
-                               return '';
-                             } else {
-                                 let value;
-                                 if (Number.isNaN(column.value)) {
-                                     value = 0;
-                                 }
-                                 if (column.value === null) {
-                                        value = 0;
-                                 } else {
-                                       value = column.value;
-                                 }
-                                 return '<a href="javascript:void(0);" title="providercount">'
-                                + value + '</a>';
-                             }
-                          }
-                    }
-            );
-
-            }
-        });
-
-        this.gridOptions.groupDefaultExpanded = -1;
-
-        this.oncologySummaryColdef = cols;
-
-    }
-
-    public translateIndicator(indicator: string) {
-        return indicator.toLowerCase().split('_').map((word) => {
-            return ((word.charAt(0).toUpperCase()) + word.slice(1));
-        }).join(' ');
-    }
-
-    public setRowData(allRowsData) {
-        const finalRows = [];
-        _.each(allRowsData, (rowData) => {
-            const rowObj = {
-            };
-            _.each(rowData, (data, index) => {
-                rowObj[index] = data;
-
-            });
-            finalRows.push(rowObj);
-
-        });
-
-        this.data = finalRows;
-        this.setTotalsRow(finalRows);
-
-    }
-
-    public setTotalsRow(rowData) {
-        const totalObj = {
-            'location_name': ''
-        };
-        const totalRow = [];
-        _.each(rowData, (row) => {
-            Object.keys(row).map((key, index) => {
-                if (Number.isInteger(row[key]) === true) {
-                    if (totalObj[key]) {
-                        totalObj[key] = row[key] + totalObj[key];
-                    } else {
-                        totalObj[key] = row[key];
-                    }
+    _.each(firstRow, (data, index) => {
+      if (index === 'encounter_datetime' || index === 'location_uuid' || index === 'location_name' ||
+        index === 'location_id') {
+        return '';
+      } else {
+        cols.push(
+          {
+            'headerName': this.translateIndicator(index),
+            'field': index,
+            cellRenderer: (column) => {
+              if (typeof column.value === 'undefined') {
+                return '';
+              } else {
+                let value;
+                if (Number.isNaN(column.value)) {
+                  value = 0;
+                }
+                if (column.value === null) {
+                  value = 0;
                 } else {
-                    if (Number.isNaN(totalObj[key])) {
-                        totalObj[key] = 0;
-                    }
-                    if (totalObj[key] === null) {
-                        totalObj[key] = 0;
-                    }
-                    totalObj[key] = 0 + totalObj[key];
+                  value = column.value;
                 }
-             });
-        });
-
-        if (totalObj['normal_breast_screening_findings']) {
-             const averageNormalRate = (totalObj['normal_breast_screening_findings'] /
-             totalObj['total_breast_screened']) * 100;
-
-             const averageAbNormalRate = (totalObj['abnormal_breast_screening_findings'] /
-             totalObj['total_breast_screened']) * 100;
-
-             totalObj['normal_breast_call_rate%'] = averageNormalRate.toFixed(2) + ' % ';
-             totalObj['abnormal_breast_call_rate%'] = averageAbNormalRate.toFixed(2) + ' % ';
-        }
-
-        if (totalObj['abnormal_cervical_screening']) {
-            const averageCervicalNormalRate = (totalObj['normal_cervical_screening'] /
-            totalObj['total_cervical_screened']) * 100;
-
-            const averageCervicalAbNormalRate = (totalObj['abnormal_cervical_screening'] /
-            totalObj['total_cervical_screened']) * 100;
-
-            totalObj['normal_cervical_call_rate%'] = averageCervicalNormalRate.toFixed(2) + ' % ';
-            totalObj['abnormal_cervical_call_rate%'] =
-            averageCervicalAbNormalRate.toFixed(2) + ' % ';
-       }
-
-        totalObj.location_name = 'Totals';
-        totalObj['encounter_datetime'] = 'Totals';
-        totalRow.push(totalObj);
-        this.pinnedBottomRowData = totalRow;
-
-        this.setPinnedRow();
-    }
-
-    public goToPatientList(data) {
-        switch (data.colDef.field) {
-
-            case 'abnormal_breast_call_rate%':
-              break;
-            case 'normal_breast_call_rate%':
-              break;
-            case 'abnormal_cervical_call_rate%':
-              break;
-            case 'normal_cervical_call_rate%':
-              break;
-            case 'total_screens':
-              break;
-            default:
-
-            let startDate;
-            let endDate;
-            let location;
-            const period = this.params.period;
-
-            if (data.data.location_name === 'Totals') {
-                startDate = this.params.startDate;
-                endDate  = this.params.endDate;
-                location = this.params.locationUuids;
-            } else {
-                if (period === 'daily') {
-                    startDate = moment(data.data.encounter_datetime, 'DD-MM-YYYY').format('YYYY-MM-DD');
-                    endDate = moment(data.data.encounter_datetime, 'DD-MM-YYYY').format('YYYY-MM-DD');
-                } else if (period === 'monthly') {
-                    startDate = moment(data.data.encounter_datetime, 'MM-YYYY').startOf('month').format('YYYY-MM-DD');
-                    endDate = moment(data.data.encounter_datetime, 'MM-YYYY').endOf('month').format('YYYY-MM-DD');
-                }
-                location = data.data.location_uuid;
+                return '<a href="javascript:void(0);" title="providercount">'
+                  + value + '</a>';
+              }
             }
+          }
+        );
+      }
+    });
+    this.gridOptions.groupDefaultExpanded = -1;
+    this.oncologySummaryColdef = cols;
+  }
 
-            // let queryParams = this.route.snapshot.params;
-            const params: any = {
-                startAge: this.params.startAge,
-                endAge: this.params.endAge,
-                gender: this.params.gender,
-                locationUuids: location,
-                locationName: data.data.location_name,
-                type: this.params.type,
-                startIndex : 0,
-                limit : 1000,
-                indicators: data.colDef.field,
-                startDate: startDate,
-                endDate: endDate,
-                period: period
-            };
+  public translateIndicator(indicator: string) {
+    return indicator.toLowerCase().split('_').map((word) => {
+      return ((word.charAt(0).toUpperCase()) + word.slice(1));
+    }).join(' ');
+  }
 
-            this.router.navigate(['patient-list']
-                , {
-                    relativeTo: this.route,
-                    queryParams: params
-                });
-           }
-    }
+  public setRowData(allRowsData) {
+    const finalRows = [];
+    _.each(allRowsData, (rowData) => {
+      const rowObj = {
+      };
+      _.each(rowData, (data, index) => {
+        rowObj[index] = data;
 
-    public exportCountsListToCsv() {
-        this.gridOptions.api.exportDataAsCsv();
-    }
+      });
+      finalRows.push(rowObj);
+    });
+    this.data = finalRows;
+    this.setTotalsRow(finalRows);
+  }
 
-    public setPinnedRow() {
-
-        if (this.gridOptions.api) {
-          this.gridOptions.api.setPinnedBottomRowData(this.pinnedBottomRowData);
+  public setTotalsRow(rowData) {
+    const totalObj = {
+      'location_name': ''
+    };
+    const totalRow = [];
+    _.each(rowData, (row) => {
+      Object.keys(row).map((key, index) => {
+        if (Number.isInteger(row[key]) === true) {
+          if (totalObj[key]) {
+            totalObj[key] = row[key] + totalObj[key];
+          } else {
+            totalObj[key] = row[key];
+          }
+        } else {
+          if (Number.isNaN(totalObj[key])) {
+            totalObj[key] = 0;
+          }
+          if (totalObj[key] === null) {
+            totalObj[key] = 0;
+          }
+          totalObj[key] = 0 + totalObj[key];
         }
-        return true;
+      });
+    });
+
+    if (totalObj['normal_findings']) {
+      const averageNormalBreastCallRate = (totalObj['normal_findings'] / totalObj['total_breast_screened']) * 100;
+      const averageAbnormalBreastCallRate = (totalObj['abnormal_findings'] / totalObj['total_breast_screened']) * 100;
+
+      totalObj['normal_breast_call_rate%'] = averageNormalBreastCallRate.toFixed(2) + ' % ';
+      totalObj['abnormal_breast_call_rate%'] = averageAbnormalBreastCallRate.toFixed(2) + ' % ';
     }
 
+    if (totalObj['abnormal_findings']) {
+      const averageCervicalNormalCallRate = (totalObj['normal_findings'] / totalObj['total_cervical_screened']) * 100;
+      const averageCervicalAbnormalCallRate = (totalObj['abnormal_findings'] / totalObj['total_cervical_screened']) * 100;
+
+      totalObj['normal_cervical_call_rate%'] = averageCervicalNormalCallRate.toFixed(2) + ' % ';
+      totalObj['abnormal_cervical_call_rate%'] = averageCervicalAbnormalCallRate.toFixed(2) + ' % ';
+    }
+    totalObj.location_name = 'Totals';
+    totalObj['encounter_datetime'] = 'Totals';
+    totalRow.push(totalObj);
+    this.pinnedBottomRowData = totalRow;
+    this.setPinnedRow();
+  }
+
+  public goToPatientList(data) {
+    switch (data.colDef.field) {
+      case 'abnormal_breast_call_rate%':
+        break;
+      case 'normal_breast_call_rate%':
+        break;
+      case 'abnormal_cervical_call_rate%':
+        break;
+      case 'normal_cervical_call_rate%':
+        break;
+      case 'total_screens':
+        break;
+      default:
+
+        let startDate;
+        let endDate;
+        let location;
+        const period = this.params.period;
+
+        if (data.data.location_name === 'Totals') {
+          startDate = this.params.startDate;
+          endDate = this.params.endDate;
+          location = this.params.locationUuids;
+        } else {
+          if (period === 'daily') {
+            startDate = moment(data.data.encounter_datetime, 'DD-MM-YYYY').format('YYYY-MM-DD');
+            endDate = moment(data.data.encounter_datetime, 'DD-MM-YYYY').format('YYYY-MM-DD');
+          } else if (period === 'monthly') {
+            startDate = moment(data.data.encounter_datetime, 'MM-YYYY').startOf('month').format('YYYY-MM-DD');
+            endDate = moment(data.data.encounter_datetime, 'MM-YYYY').endOf('month').format('YYYY-MM-DD');
+          }
+          location = data.data.location_uuid;
+        }
+
+        const params: any = {
+          startAge: this.params.startAge,
+          endAge: this.params.endAge,
+          gender: this.params.gender,
+          locationUuids: location,
+          locationName: data.data.location_name,
+          type: this.params.type,
+          startIndex: 0,
+          limit: 1000,
+          indicators: data.colDef.field,
+          startDate: startDate,
+          endDate: endDate,
+          period: period
+        };
+
+        this.router.navigate(['patient-list'], {
+          relativeTo: this.route,
+          queryParams: params
+        });
+    }
+  }
+
+  public exportCountsListToCsv() {
+    this.gridOptions.api.exportDataAsCsv();
+  }
+
+  public setPinnedRow() {
+    if (this.gridOptions.api) {
+      this.gridOptions.api.setPinnedBottomRowData(this.pinnedBottomRowData);
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
This PR adds new columns to the breast screening and cervical screening reports. The following columns are added to the breast screening and cervical screening aggregate report:

- male_patients (count)
- female_patients (count)
- hiv_negative (count)
- hiv_status_unknown (count)
- hiv_positive (count)

The columns in the aggregate are also reordered so that normal and abnormal findings are arranged consecutively for easier side-by-side comparison. The Location and Period columns are pinned so that they always stay visible when scrolling across the report. 

It also modifies the patient list for breast screening patients with abnormal findings to include the following columns:

- breast_mass_location
- nipple_discharge_location
- nipple_retraction_location
- breast_erythrema_location
- breast_rash_location
- breast_pain_location
- other_changes_location
- history_of_mammogram
- mammogram_results
- breast_ultrasound_history
- breast_ultrasound_result
- history_of_breast_biopsy
- breast_biopsy_results
- number_of_biopsies
- biopsy_type

As well as the patient list for cervical screening patients with abnormal findings to include the following columns:

- prior_via_done
- prior_via_date
- prior_via_result
- visual_impression_cervix
- visual_impression_vagina
- visual_impression_vulva
- via_procedure_done
- via_management_plan
- via_rtc_date