### PR TITLE
POCONC-192: Fix shared referral patient lists

### DIFF
--- a/src/app/etl-api/patient-referral-resource.service.spec.ts
+++ b/src/app/etl-api/patient-referral-resource.service.spec.ts
@@ -1,38 +1,35 @@
-import { TestBed, async, inject, fakeAsync } from '@angular/core/testing';
-import { LocalStorageService } from '../utils/local-storage.service';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
+
 import { CacheModule, CacheService } from 'ionic-cache';
+import { CacheStorageService } from 'ionic-cache/dist/cache-storage';
 import { AppSettingsService } from '../app-settings/app-settings.service';
 import { DataCacheService } from '../shared/services/data-cache.service';
+import { LocalStorageService } from '../utils/local-storage.service';
 import { PatientReferralResourceService } from './patient-referral-resource.service';
-import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
-import { CacheStorageService } from 'ionic-cache/dist/cache-storage';
+
+const basePath = 'api-base-path/';
 
 class MockCacheStorageService {
   constructor(a, b) { }
 
-  public ready() {
+  ready() {
     return true;
   }
 }
-const expectedPatientReferralResults = {
-  startIndex: 0,
-  size: 1,
-  result: [
-    {
-      location: 'location name',
-      location_uuid: 'location-uuid',
-      program_uuid: 'program_uuid',
-      location_id: 13,
-      encounter_datetime: '2017-04-26T05:48:32.000Z',
-      received_back: 89,
-    }
-  ],
-  indicatorDefinitions: [{
 
-  }]
-};
+class MockAppSettingsService {
+  getEtlRestbaseurl() {
+    return basePath;
+  }
+}
 
-const reportParams = {
+const mockReportParams = {
   startIndex: undefined,
   startDate: '2017-03-01',
   locationUuids: '08fec056-1352-11df-a1f1-0026b9348838',
@@ -42,105 +39,200 @@ const reportParams = {
   gender: 'M,F',
   stateUuids: 'stateUuids-uuid',
   startAge: 0,
-  endAge: 110
+  endAge: 110,
 };
 
-const patientList = {
-  startIndex: 0,
-  size: 3,
-  result: [
-    {
-      person_id: 1817,
-      encounter_id: 6774060,
-      location_id: 13,
-      location_uuid: '08fec056-1352-11df-a1f1-0026b9348838',
-      patient_uuid: '5b737014-1359-11df-a1f1-0026b9348838',
-      gender: 'F',
-      birthdate: '1982-12-11T21:00:00.000Z',
-      age: 34
+describe('PatientReferralResourceService', () => {
+  let cacheService: DataCacheService;
+  let patientReferralResourceService: PatientReferralResourceService;
+  let httpMock: HttpTestingController;
 
-    }
-  ]
-};
-
-describe('PatientReferralResourceService Tests', () => {
-  let service, httpMok;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [],
       imports: [CacheModule, HttpClientTestingModule],
       providers: [
-        PatientReferralResourceService,
-        AppSettingsService,
-        LocalStorageService,
         CacheService,
         DataCacheService,
+        LocalStorageService,
+        PatientReferralResourceService,
         {
-          provide: CacheStorageService, useFactory: () => {
+          provide: AppSettingsService,
+          useClass: MockAppSettingsService,
+        },
+        {
+          provide: CacheStorageService,
+          useFactory: () => {
             return new MockCacheStorageService(null, null);
-          }
-        }
-      ]
+          },
+        },
+      ],
     });
-    service = TestBed.get(PatientReferralResourceService);
-    httpMok = TestBed.get(HttpTestingController);
+
+    cacheService = TestBed.get(DataCacheService);
+    patientReferralResourceService = TestBed.get(
+      PatientReferralResourceService
+    );
+    httpMock = TestBed.get(HttpTestingController);
   });
 
   afterEach(() => {
-    TestBed.resetTestingModule();
+    httpMock.verify();
   });
 
-  it('should be defined',
-    inject([PatientReferralResourceService],
-      (s: PatientReferralResourceService) => {
-        expect(s).toBeTruthy();
-      })
-  );
+  it('fetches and returns referral report data', () => {
+    const expectedReferralReport = {
+      startIndex: 0,
+      size: 1,
+      result: [
+        {
+          location: 'location name',
+          location_uuid: 'location-uuid',
+          program_uuid: 'program_uuid',
+          location_id: 13,
+          encounter_datetime: '2017-04-26T05:48:32.000Z',
+          received_back: 89,
+        },
+      ],
+      indicatorDefinitions: [{}]
+    };
 
-  it('Patient referral resource service resource methods should be defined',
-    inject([PatientReferralResourceService],
-      (s: PatientReferralResourceService) => {
-        expect(s.getUrl).toBeDefined();
-        expect(s.getPatientListUrl).toBeDefined();
-        expect(s.getPatientReferralReport).toBeDefined();
-        expect(s.getPatientReferralPatientList).toBeDefined();
-      })
-  );
+    const dataCacheServiceSpy: jasmine.Spy = spyOn(
+        cacheService,
+        'cacheSingleRequest'
+    ).and.callFake(() => of(expectedReferralReport));
 
-  it('should return report urlRequest parameters',
-    inject([PatientReferralResourceService],
-      (s: PatientReferralResourceService) => {
-        const urlParams = s.getUrlRequestParams(reportParams);
-        const params = urlParams.toString();
-        expect(params).toContain('locationUuids=08fec056-1352-11df-a1f1-0026b9348838');
-        expect(params).toContain('endDate=2017-04-27');
-        expect(params).toContain('gender=M,F');
-        expect(params).toContain('startDate=2017-03-01');
-        expect(params).toContain('stateUuids=stateUuids-uuid');
-        expect(params).toContain('endAge=110');
+    patientReferralResourceService
+      .getPatientReferralReport(mockReportParams)
+      .subscribe(
+        referralReport =>
+          expect(referralReport).toEqual(
+            expectedReferralReport, 'returns the referral report'
+          ),
+          fail
+      );
 
-      }
-    )
-  );
-
-  it('should return Patient referral  Report', () => {
-
-    service.getPatientReferralReport(reportParams).subscribe((result) => {
-      expect(result).toBeDefined();
-      expect(result).toEqual(expectedPatientReferralResults);
-    });
-
+    expect(dataCacheServiceSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should return Patient referral Report Patient List', () => {
+  it('fetches and returns referral patient list data', () => {
+    const expectedReferralPatientList = {
+      startIndex: 0,
+      size: 1,
+      result: [
+        {
+          person_id: 1817,
+          encounter_id: 6774060,
+          location_id: 13,
+          location_uuid: '08fec056-1352-11df-a1f1-0026b9348838',
+          patient_uuid: '5b737014-1359-11df-a1f1-0026b9348838',
+          gender: 'F',
+          birthdate: '1982-12-11T21:00:00.000Z',
+          age: 34
+        },
+      ],
+    };
 
-    service.getPatientReferralPatientList(reportParams).subscribe((result) => {
-      expect(result).toBeDefined();
-      expect(result).toEqual(patientList.result);
-    });
-    /*const req = httpMok.expectOne(service.getPatientListUrl() + '?endDate=2017-04-27&startDate=2017-03-01&gender=M,F&locationUuids=' +
-      '08fec056-1352-11df-a1f1-0026b9348838&startAge=0&endAge=110&programUuids=program-uuid&stateUuids=stateUuids-uuid&limit=300');
-    req.flush(patientList);*/
+    const dataCacheServiceSpy = spyOn(
+      cacheService,
+      'cacheSingleRequest'
+    ).and.callFake(() => of(expectedReferralPatientList));
+
+    patientReferralResourceService
+      .getPatientReferralPatientList(mockReportParams)
+      .subscribe(
+        referralPatientList =>
+          expect(referralPatientList).toEqual(
+            expectedReferralPatientList,
+            'returns referral patient list data'
+          ),
+          fail
+       );
+
+    expect(dataCacheServiceSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('fetches and returns referral data given the referral location uuid and/or the enrollment uuid', () => {
+    const expectedReferralData = {
+      startIndex: 0,
+      size: 1,
+      result: [
+        {
+          encounter_uuid: 'test-encounter-uuid',
+          notification_status: null,
+          patient_program_id: 89,
+          patient_program_uuid: 'test-patient-program-uuid',
+          patient_referral_id: 6789,
+          provider_id: 123,
+          referred_from_location: 'location A',
+          referred_from_location_id: 1,
+          referred_from_location_uuid: 'location-a-uuid',
+          referred_to_location: 'location B',
+          referred_to_location_id: 2,
+          referred_to_location_uuid: 'location-b-uuid',
+          voided: 0
+        }
+      ],
+      indicatorDefinitions: [{}]
+    };
+
+    const testPayload = {
+      locationUuid: 'test-location-uuid',
+      enrollmentUuid: 'test-enrollment-uuid'
+    };
+
+    patientReferralResourceService
+      .getReferralByLocationUuid(
+        testPayload.locationUuid,
+        testPayload.enrollmentUuid
+      )
+      .subscribe(
+        referralData => expect(referralData).toEqual(
+          expectedReferralData,
+          'returns referral data'
+        ),
+        fail
+      );
+
+    const req = httpMock.expectOne(
+      (r) =>
+        r.method === 'GET' &&
+        r.url ===
+        `${basePath}patient-referral-details/test-location-uuid/test-enrollment-uuid`
+    );
+    expect(req.request.method).toEqual('GET');
+    req.flush(expectedReferralData);
+  });
+
+  it('updates the status of a pending referral upon successful completion', () => {
+    const expectedReferralData = {
+      encounter_id: 1234567,
+      notification_status: '1',
+      patient_program_id: 89,
+      patient_referral_id: 6789,
+      provider_id: 123,
+      referral_reason: 'Test referral',
+      referred_from_location_id: 1,
+      referred_to_location_id: 2,
+      voided: 0,
+    };
+
+    const testPayload = {
+      notificationStatus: 1,
+      patient_referral_id: 123,
+    };
+
+    patientReferralResourceService
+      .updateReferralNotificationStatus(testPayload)
+      .subscribe(
+        referralData => expect(referralData).toEqual(
+          expectedReferralData,
+          'returns updated referral data'
+          ),
+        fail
+      );
+
+    const req = httpMock.expectOne(`${basePath}patient-referral/123`);
+    expect(req.request.method).toEqual('POST');
+    req.flush(expectedReferralData);
+  });
 });

--- a/src/app/program-manager/patient-referral.service.ts
+++ b/src/app/program-manager/patient-referral.service.ts
@@ -1,30 +1,29 @@
-
-import {take} from 'rxjs/operators';
 import { Injectable } from '@angular/core';
+
+import { Observable, BehaviorSubject } from 'rxjs';
+import { take } from 'rxjs/operators';
+
 import * as _ from 'lodash';
 import * as moment from 'moment';
-import { Observable ,  BehaviorSubject } from 'rxjs';
 
 import { ProgramService } from '../patient-dashboard/programs/program.service';
 import { EncounterResourceService } from '../openmrs-api/encounter-resource.service';
 import { ProgramReferralResourceService } from '../etl-api/program-referral-resource.service';
-import {
-    ProviderResourceService
-} from '../openmrs-api/provider-resource.service';
+import { ProviderResourceService } from '../openmrs-api/provider-resource.service';
 import { PatientProgramResourceService } from '../etl-api/patient-program-resource.service';
 import { PatientReferralResourceService } from '../etl-api/patient-referral-resource.service';
 
 @Injectable()
 export class PatientReferralService {
   public formsComplete: BehaviorSubject<any> = new BehaviorSubject(null);
-  constructor(private programService: ProgramService,
-              private patientProgramResourceService: PatientProgramResourceService,
-              private programReferralResourceService: ProgramReferralResourceService,
-              private encounterResourceService: EncounterResourceService,
-              private providerResourceService: ProviderResourceService,
-              private patientReferralResourceService: PatientReferralResourceService) {
-
-  }
+  constructor(
+    private programService: ProgramService,
+    private patientProgramResourceService: PatientProgramResourceService,
+    private programReferralResourceService: ProgramReferralResourceService,
+    private encounterResourceService: EncounterResourceService,
+    private providerResourceService: ProviderResourceService,
+    private patientReferralResourceService: PatientReferralResourceService
+  ) {}
 
   public createUpdatePatientEnrollment(payload) {
     const enrollPayload = this.programService.createEnrollmentPayload(
@@ -33,7 +32,8 @@ export class PatientReferralService {
       payload.dateEnrolled || this.toOpenmrsDateFormat(new Date()),
       payload.dateCompleted ? payload.dateCompleted : null,
       payload.location,
-      payload.enrollmentUuid);
+      payload.enrollmentUuid
+    );
     return this.programService.saveUpdateProgramEnrollment(enrollPayload);
   }
 
@@ -42,20 +42,22 @@ export class PatientReferralService {
   }
 
   public getReferredByLocation(locationUuid, enrollmentUud?): Observable<any> {
-    return this.patientReferralResourceService
-      .getReferralByLocationUuid(locationUuid, enrollmentUud);
-
+    return this.patientReferralResourceService.getReferralByLocationUuid(
+      locationUuid,
+      enrollmentUud
+    );
   }
 
   public getEncounterProvider(encounterUuid: string): Observable<any> {
     const subject: BehaviorSubject<any> = new BehaviorSubject<any>(null);
-    this.encounterResourceService.getEncounterByUuid(encounterUuid).pipe(
-      take(1)).subscribe((encounter) => {
+    this.encounterResourceService
+      .getEncounterByUuid(encounterUuid)
+      .pipe(take(1))
+      .subscribe((encounter) => {
         const encounterProvider: any = _.first(encounter.encounterProviders);
         if (encounterProvider) {
           subject.next(encounterProvider.provider);
         }
-
       });
     return subject;
   }
@@ -64,14 +66,15 @@ export class PatientReferralService {
     return new Promise((resolve, reject) => {
       if (user && user.person) {
         this.providerResourceService
-          .getProviderByPersonUuid(user.person.uuid).pipe(
-          take(1)).subscribe(
-          (provider) => {
-            resolve(provider);
-          },
-          (error) => {
-            reject(error);
-          }
+          .getProviderByPersonUuid(user.person.uuid)
+          .pipe(take(1))
+          .subscribe(
+            (provider) => {
+              resolve(provider);
+            },
+            (error) => {
+              reject(error);
+            }
           );
       } else {
         reject('User is required');
@@ -81,63 +84,54 @@ export class PatientReferralService {
 
   public fetchAllProgramManagementConfigs(patientUuid): Observable<any> {
     const subject: BehaviorSubject<any> = new BehaviorSubject<any>(null);
-    this.patientProgramResourceService.getPatientProgramVisitConfigs(patientUuid).pipe(
-      take(1)).subscribe((programConfigs) => {
-      subject.next(programConfigs);
-    });
+    this.patientProgramResourceService
+      .getPatientProgramVisitConfigs(patientUuid)
+      .pipe(take(1))
+      .subscribe((programConfigs) => {
+        subject.next(programConfigs);
+      });
     return subject;
   }
 
   public getReferralPatientList(params: any) {
     const referralInfo: BehaviorSubject<any> = new BehaviorSubject<any>([]);
-    const referralObservable = this.patientReferralResourceService
-      .getPatientReferralPatientList({
-      endDate: params.endDate,
-      locationUuids: params.locationUuids,
-      startDate: params.startDate,
-      startAge: params.startAge,
-      programUuids: params.programUuids,
-      startIndex: params.startIndex
-    });
+    const referralObservable = this.patientReferralResourceService.getPatientReferralPatientList(
+      {
+        endDate: params.endDate,
+        locationUuids: params.locationUuids,
+        startDate: params.startDate,
+        startAge: params.startAge,
+        programUuids: params.programUuids,
+        startIndex: params.startIndex,
+      }
+    );
 
     if (referralObservable === null) {
       throw new Error('Null referral provider observable');
     } else {
-      referralObservable.take(1).subscribe(
-          (referrals) => {
-              referralInfo.next(referrals);
-           });
-  }
+      referralObservable.take(1).subscribe((referrals) => {
+        referralInfo.next(referrals);
+      });
+    }
     return referralInfo.asObservable();
   }
 
   public getProgramWorkflows(programUuid) {
     const subject: BehaviorSubject<any> = new BehaviorSubject<any>(null);
-    this.programService.getProgramWorkFlows(programUuid).take(1).subscribe((workflows: any[]) => {
-      const programWorkflows = _.filter(workflows, (w) => !w.retired);
-      subject.next(programWorkflows.length > 0);
-    });
+    this.programService
+      .getProgramWorkFlows(programUuid)
+      .take(1)
+      .subscribe((workflows: any[]) => {
+        const programWorkflows = _.filter(workflows, (w) => !w.retired);
+        subject.next(programWorkflows.length > 0);
+      });
     return subject;
   }
 
-  public getProgramEnrollmentReferralLocation(enrollmentUuid: any) {
-    const referral: BehaviorSubject<any> = new BehaviorSubject<any>([]);
-    const referralObservable = this.patientReferralResourceService.getReferralByLocationUuid
-    (enrollmentUuid);
-
-    if (referralObservable === null) {
-      throw new Error('Null referral location observable');
-    } else {
-      referralObservable.pipe(take(1)).subscribe(
-          (referrals) => {
-              referral.next(referrals);
-           });
-  }
-    return referral.asObservable();
-  }
-
   public updateReferalNotificationStatus(payload) {
-    return this.patientReferralResourceService.updateReferralNotificationStatus(payload);
+    return this.patientReferralResourceService.updateReferralNotificationStatus(
+      payload
+    );
   }
 
   public getReferralEncounterDetails(encounterUuid) {
@@ -151,5 +145,4 @@ export class PatientReferralService {
     }
     return '';
   }
-
 }

--- a/src/app/program-manager/program-referral-report-base/patient-referral-report-base.component.html
+++ b/src/app/program-manager/program-referral-report-base/patient-referral-report-base.component.html
@@ -1,20 +1,34 @@
-<h4 class="component-title" style="color: green;"><span class="glyphicon glyphicon-equalizer"></span> Patient Referral</h4>
+<h4 class="component-title" style="color: green;">
+  <span class="glyphicon glyphicon-equalizer"></span> Patient Referrals
+</h4>
 <div>
   <div class="row">
     <div class="col-md-12 col-lg-12 col-sm-12 col-xs-12">
-      <div class="alert alert-danger" *ngIf="msgObj.show && msgObj.message !== ''">
+      <div
+        class="alert alert-danger"
+        *ngIf="msgObj.show && msgObj.message !== ''"
+      >
         {{ msgObj.message }}
       </div>
     </div>
   </div>
-  <report-filters [enabledControls]="enabledControls" [(startDate)]="startDate" [(endDate)]="endDate"
-                   (onProgramChange)="getSelectedPrograms($event)"
-                   [reportName]="reportName" [parentIsBusy]="isLoadingReport"
-                   (generateReport)="generateReport()">
+  <report-filters
+    [enabledControls]="enabledControls"
+    [(startDate)]="startDate"
+    [(endDate)]="endDate"
+    (onProgramChange)="getSelectedPrograms($event)"
+    [reportName]="reportName"
+    [parentIsBusy]="isLoadingReport"
+    (generateReport)="generateReport()"
+  >
   </report-filters>
   <div *ngIf="data.length > 0">
-    <patient-referral-tabular [sectionDefs]="sectionsDef" [rowData]="data" [dates]="dates"
-      [programUuids]="programUuids"></patient-referral-tabular>
+    <patient-referral-tabular
+      [sectionDefs]="sectionsDef"
+      [rowData]="data"
+      [dates]="dates"
+      [programUuids]="programUuids"
+    ></patient-referral-tabular>
   </div>
   <div class="row" *ngIf="showEmptyResultsDialog">
     <div class="col-md-12 col-lg-12 col-sm-12 col-xs-12">

--- a/src/app/program-manager/program-referral-report-base/patient-referral-report-base.component.ts
+++ b/src/app/program-manager/program-referral-report-base/patient-referral-report-base.component.ts
@@ -128,7 +128,7 @@ export class PatientReferralBaseComponent implements OnInit {
             this.data = groupedProgramData;
           }
         }, (error) => {
-          console.log('error => ', error);
+          console.error('Error fetching referral report: ', error);
           this.isLoadingReport = false;
           this.errorMessage = error;
           this.encounteredError = true;

--- a/src/app/program-manager/program-referral-report-base/patient-referral-tabular.component.html
+++ b/src/app/program-manager/program-referral-report-base/patient-referral-tabular.component.html
@@ -1,5 +1,11 @@
-<ag-grid-angular #agGrid style="width: 100%; height: 200px;" class="ag-blue" [rowData]="data" [gridOptions]="gridOptions"
-  (cellClicked)='onCellClicked($event)'>
+<ag-grid-angular
+  #agGrid
+  style="width: 100%; height: 200px;"
+  class="ag-blue"
+  [rowData]="data"
+  [gridOptions]="gridOptions"
+  (cellClicked)="onCellClicked($event)"
+>
 </ag-grid-angular>
 
 <div>
@@ -7,7 +13,11 @@
     <span><i class="fa fa-spinner fa-spin"></i>Loading...</span>
   </div>
   <div *ngIf="patientData.length > 0">
-    <h3>{{ programName | titlecase }} Referral Patient List</h3>
-    <patient-list [extraColumns]="extraColumns" [overrideColumns]="overrideColumns" [data]="patientData"></patient-list>
+    <h4>{{ programName | titlecase }} referral patient list</h4>
+    <patient-list
+      [extraColumns]="extraColumns"
+      [overrideColumns]="overrideColumns"
+      [data]="patientData"
+    ></patient-list>
   </div>
 </div>

--- a/src/app/program-manager/program-referral-report-base/patient-referral-tabular.component.ts
+++ b/src/app/program-manager/program-referral-report-base/patient-referral-tabular.component.ts
@@ -1,9 +1,10 @@
-import { Component, OnInit, ChangeDetectionStrategy, Input, ViewChild } from '@angular/core';
+import { Component, OnInit, Input, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
+
 import * as _ from 'lodash';
-import { AgGridNg2 } from 'ag-grid-angular';
-import { Router, ActivatedRoute } from '@angular/router';
 import * as Moment from 'moment';
-import { Subscription } from 'rxjs';
+import { AgGridNg2 } from 'ag-grid-angular';
+
 import {
   PatientReferralResourceService
 } from '../../etl-api/patient-referral-resource.service';
@@ -11,8 +12,7 @@ import { SelectDepartmentService } from '../../shared/services/select-department
 
 @Component({
   selector: 'patient-referral-tabular',
-  templateUrl: 'patient-referral-tabular.component.html',
-  // changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: 'patient-referral-tabular.component.html'
 })
 
 export class PatientReferralTabularComponent implements OnInit {
@@ -61,7 +61,6 @@ export class PatientReferralTabularComponent implements OnInit {
   public set sectionDefs(v: Array<any>) {
     this._sectionDefs = v;
     this.setColumns(v);
-
   }
 
   private _dates: any;
@@ -163,7 +162,6 @@ export class PatientReferralTabularComponent implements OnInit {
       department: this.department
     }).take(1).subscribe((report) => {
       this.patientData = report;
-      // this.patientData ? this.patientData.concat(report) : report;
       this.isLoading = false;
       this.startIndex += report.length;
       if (report.length < 300) {
@@ -216,20 +214,14 @@ export class PatientReferralTabularComponent implements OnInit {
     });
   }
 
-  public loadMorePatients() {
-    // this.generatePatientListReport();
-  }
-
   public redirectToPatientInfo(patientUuid) {
     if (patientUuid === undefined || patientUuid === null) {
       return;
     }
     this.router.navigate(['/patient-dashboard/patient/' + patientUuid + '/general/general']);
-
   }
 
   private toDateString(date: Date): string {
     return Moment(date).utcOffset('+03:00').format();
   }
-
 }

--- a/src/app/program-manager/program-referral-report-base/referral-report-base.component.html
+++ b/src/app/program-manager/program-referral-report-base/referral-report-base.component.html
@@ -1,22 +1,33 @@
-<h4 class="component-title" style="color: green;"><span class="glyphicon glyphicon-equalizer"></span>Patient Referral</h4>
+<h4 class="component-title" style="color: green;">
+  <span class="glyphicon glyphicon-equalizer"></span>Patient Referrals
+</h4>
 
 <div>
-  <report-filters  [enabledControls]="enabledControls" [(startDate)]="startDate" [(endDate)]="endDate"
-                   [start]="ageRangeStart" [end]="ageRangeEnd"
-                   (onAgeChangeFinish)="onAgeChangeFinished($event)"
-                   (onGenderChange)="getSelectedGender($event)"
-                   (onProgramChange)="getSelectedPrograms($event)"
-                   (onselectedLocationChange) ="getLocations($event)"
-                   [selectedGender]="selectedGender"
-
-
-                   [reportName]="reportName" [parentIsBusy]="isLoadingReport"
-                   (generateReport)="generateReport()">
+  <report-filters
+    [enabledControls]="enabledControls"
+    [(startDate)]="startDate"
+    [(endDate)]="endDate"
+    [start]="ageRangeStart"
+    [end]="ageRangeEnd"
+    (onAgeChangeFinish)="onAgeChangeFinished($event)"
+    (onGenderChange)="getSelectedGender($event)"
+    (onProgramChange)="getSelectedPrograms($event)"
+    (onselectedLocationChange)="getLocations($event)"
+    [selectedGender]="selectedGender"
+    [reportName]="reportName"
+    [parentIsBusy]="isLoadingReport"
+    (generateReport)="generateReport()"
+  >
   </report-filters>
-  <br/>
-  <br/>
-  <patient-referral-tabular [sectionDefs]="sectionsDef"  [rowData]="data" [dates]="dates" [gender]="gender"
-                   [programUuids]="programUuids"  [age]="age" [provider]="provider"></patient-referral-tabular>
-
-
+  <br />
+  <br />
+  <patient-referral-tabular
+    [sectionDefs]="sectionsDef"
+    [rowData]="data"
+    [dates]="dates"
+    [gender]="gender"
+    [programUuids]="programUuids"
+    [age]="age"
+    [provider]="provider"
+  ></patient-referral-tabular>
 </div>

--- a/src/app/shared/data-lists/patient-list/patient-list.component.ts
+++ b/src/app/shared/data-lists/patient-list/patient-list.component.ts
@@ -1,6 +1,5 @@
 import {
-  Component, OnInit, Input, Output,
-  EventEmitter
+  Component, OnInit, Input
 } from '@angular/core';
 import { PatientListColumns } from './patient-list-columns.data';
 import { Router } from '@angular/router';
@@ -11,8 +10,8 @@ const _ = require('lodash');
   selector: 'patient-list',
   templateUrl: './patient-list.component.html'
 })
-export class PatientListComponent implements OnInit {
 
+export class PatientListComponent implements OnInit {
   @Input() public extraColumns: any;
   @Input() public overrideColumns: any;
   @Input() public data: any = [];
@@ -37,7 +36,7 @@ export class PatientListComponent implements OnInit {
   private _dataSource = new BehaviorSubject<any>({});
   constructor(
     private router: Router
-    ) {
+  ) {
   }
 
   public ngOnInit() {
@@ -101,5 +100,4 @@ export class PatientListComponent implements OnInit {
     this.router.navigate(['/patient-dashboard/patient/' + patientUuid +
       '/general/general/landing-page']);
   }
-
 }


### PR DESCRIPTION
Presently, referral patient lists (_found under Clinic Dashboard > Patient Referral_) for the Hemato-Oncology and CDM departments are not working as they should.

The logic for this feature was written such that both departments could reuse the same base and aggregate reports, as well as displaying the same report indicators in the UI. The shared URL endpoint for these reports was modified at some point, which is why they stopped working. The aim of this change was likely to try and get the peer navigator tracking patient list used by the CDM department working. Currently, neither the peer navigator tracking patient list nor the referral patient lists are working in production.

This PR sets the URL endpoint back to the appropriate one and gets the referral patient lists back working again. It also:

- Adds a check to ensure that test patients do not appear in the patient lists.
- Enhances readability by formatting clients' names to title case.
- Sorts referrals by `date referred` in descending order.

**Note**: This PR does not fix the peer navigator tracking patient list.