### PR TITLE
HIV-660: Restore edit button to address section of patient info

### DIFF
--- a/src/app/patient-dashboard/common/patient-info/patient-info.component.html
+++ b/src/app/patient-dashboard/common/patient-info/patient-info.component.html
@@ -37,6 +37,7 @@
 <div class="row patient-info-row">
   <div class="col-md-12 col-sm-12 col-lg-12 col-xs-12">
     <h5 class="info_section_title">Address </h5>
+    <a (click)="address.showDialog()" class="edit_link"><span><i class="fa fa-edit fa-fw"></i> Edit</span></a>
   </div>
   <address></address>
   <edit-address #address></edit-address>


### PR DESCRIPTION
https://jira.ampath.or.ke/browse/HIV-660

Edit functionality was removed [perhaps erroneously](https://github.com/AMPATH/ng2-amrs/pull/1286/files#diff-2b0c54b9eeaf44a084066d51f4f516ba), from the Address section of the patient information page. This PR restores the edit button.

![Screenshot 2020-09-01 at 13 56 24](https://user-images.githubusercontent.com/8509731/91841468-1cf1a900-ec5b-11ea-8d80-9ac68a79cdef.png)
