### PR TITLE
Add check so scrollIntoView is invoked conditionally

### DIFF
--- a/src/app/patient-dashboard/common/patient-info/patient-info.component.ts
+++ b/src/app/patient-dashboard/common/patient-info/patient-info.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy , AfterViewInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, AfterViewInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { AppFeatureAnalytics } from '../../../shared/app-analytics/app-feature-analytics.service';
 import { PatientService } from '../../services/patient.service';
@@ -9,17 +9,18 @@ import { Subscription } from 'rxjs';
 @Component({
   selector: 'app-patient-info',
   templateUrl: './patient-info.component.html',
-  styleUrls: ['./patient-info.component.css']
+  styleUrls: ['./patient-info.component.css'],
 })
 export class PatientInfoComponent implements OnInit, OnDestroy, AfterViewInit {
-
   public patient: Patient;
   public subscription: Subscription;
   public routeSub: Subscription;
   public scrollSection = '';
-  constructor(private appFeatureAnalytics: AppFeatureAnalytics,
-    private patientService: PatientService, private route: ActivatedRoute) {
-  }
+  constructor(
+    private appFeatureAnalytics: AppFeatureAnalytics,
+    private patientService: PatientService,
+    private route: ActivatedRoute
+  ) {}
   public ngOnInit() {
     this.subscription = this.patientService.currentlyLoadedPatient.subscribe(
       (patient) => {
@@ -29,12 +30,14 @@ export class PatientInfoComponent implements OnInit, OnDestroy, AfterViewInit {
         }
       }
     );
-    this.appFeatureAnalytics
-      .trackEvent('Patient Dashboard', 'Patient Info Loaded', 'ngOnInit');
-    this.routeSub = this.route.queryParams
-    .subscribe((params: any) => {
+    this.appFeatureAnalytics.trackEvent(
+      'Patient Dashboard',
+      'Patient Info Loaded',
+      'ngOnInit'
+    );
+    this.routeSub = this.route.queryParams.subscribe((params: any) => {
       if (params.scrollSection) {
-          this.scrollSection = params.scrollSection;
+        this.scrollSection = params.scrollSection;
       }
     });
   }
@@ -44,27 +47,28 @@ export class PatientInfoComponent implements OnInit, OnDestroy, AfterViewInit {
       this.subscription.unsubscribe();
     }
     if (this.routeSub) {
-          this.routeSub.unsubscribe();
+      this.routeSub.unsubscribe();
     }
   }
 
   public ngAfterViewInit() {
-    if (this.scrollSection !== '' || typeof this.scrollSection !== 'undefined') {
+    if (
+      this.scrollSection !== '' ||
+      typeof this.scrollSection !== 'undefined'
+    ) {
       setTimeout(() => {
         this.scrollToSection(this.scrollSection);
       }, 3000);
-
     }
   }
 
   public scrollToSection(section: string) {
-        console.log('scroll section', section);
-        const element = document.getElementById(section);
-        console.log('scroll element', element);
-        element.scrollIntoView({
-          behavior: 'smooth',
-          block: 'center'
-        });
+    const element = document.getElementById(section);
+    if (element) {
+      element.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+    }
   }
-
 }


### PR DESCRIPTION
![Screenshot 2020-09-01 at 15 43 46](https://user-images.githubusercontent.com/8509731/91853097-64cbfc80-ec6a-11ea-930d-65985542d348.png)

Presently, we have logic that enables [Element.scrollIntoView](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) to be called on a domElement that can be specified by providing a query parameter in the URL. When the user navigates to the patient info page, the specified element will be scrolled into the visible area of the browser window.

This PR adds a check that ensures that the specified element exists before calling `scrollIntoView` on it.

Ignore the diff noise (that's due to linting). The actual change is adding the `if` check on line 67.