### PR TITLE
Fix form list loading so that only the correct forms are loaded

### DIFF
--- a/src/app/patient-dashboard/common/forms/form-list.service.spec.ts
+++ b/src/app/patient-dashboard/common/forms/form-list.service.spec.ts
@@ -1,246 +1,231 @@
-
-import { TestBed, async, inject } from '@angular/core/testing';
-import { of } from 'rxjs';
-
-import { FormListService } from './form-list.service';
-import { FormsResourceService } from '../../../openmrs-api/forms-resource.service';
-import { LocalStorageService } from '../../../utils/local-storage.service';
-import { AppSettingsService } from '../../../app-settings/app-settings.service';
-import { FormOrderMetaDataService } from './form-order-metadata.service';
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import * as _ from 'lodash';
 import { forms } from './forms';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AppSettingsService } from '../../../app-settings/app-settings.service';
+import { FormListService } from './form-list.service';
+import { FormOrderMetaDataService } from './form-order-metadata.service';
+import { FormsResourceService } from '../../../openmrs-api/forms-resource.service';
+import { LocalStorageService } from '../../../utils/local-storage.service';
 
 describe('FormListService', () => {
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            declarations: [],
-            providers: [
-                FormListService,
-                FormsResourceService,
-                LocalStorageService,
-                FormOrderMetaDataService,
-                AppSettingsService,
-                HttpClientTestingModule
-            ],
-            imports: [
-                HttpClientTestingModule
-            ]
-        });
+  let service: FormListService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [],
+      providers: [
+        FormListService,
+        FormsResourceService,
+        LocalStorageService,
+        FormOrderMetaDataService,
+        AppSettingsService,
+        HttpClientTestingModule,
+      ],
+      imports: [HttpClientTestingModule],
     });
 
-    afterEach(() => {
-        TestBed.resetTestingModule();
-    });
+    service = TestBed.get(FormListService);
+  });
 
-    it('should be defined',
-        inject([FormListService], (service: FormListService) => {
-            expect(service).toBeTruthy();
-        })
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('should sort an array of forms given an unsorted array and sorting metadata', () => {
+    const favourite = [
+      {
+        name: 'form 5',
+      },
+      {
+        name: 'form 3',
+      },
+    ];
+
+    const defaultOrder = [
+      {
+        name: 'form 2',
+      },
+      {
+        name: 'form 3',
+      },
+    ];
+
+    const expectedOrder = [
+      {
+        name: 'form 5',
+        published: false,
+        uuid: 'uuid5-unpublished',
+        version: '1.0',
+      },
+      {
+        name: 'form 3',
+        published: false,
+        uuid: 'uuid3',
+        version: '1.0',
+      },
+      {
+        name: 'form 2',
+        published: true,
+        uuid: 'uuid2',
+        version: '1.0',
+      },
+      {
+        name: 'form 1',
+        published: true,
+        uuid: 'uuid',
+        version: '1.0',
+      },
+      {
+        name: 'form 4',
+        published: true,
+        uuid: 'uuid4',
+        version: '1.0',
+      },
+      {
+        name: 'form 4',
+        published: false,
+        uuid: 'uuid4-unpublished',
+        version: '2.0',
+      },
+    ];
+
+    const actualOrder = service.sortFormList(forms, [favourite, defaultOrder]);
+
+    expect(actualOrder.length).toEqual(expectedOrder.length);
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+
+  it('should filter out unpublished OpenMRS forms from the form list', () => {
+    const expectedFilteredList = [
+      {
+        name: 'form 1',
+        published: true,
+        uuid: 'uuid',
+        version: '1.0',
+      },
+      {
+        name: 'form 2',
+        published: true,
+        uuid: 'uuid2',
+        version: '1.0',
+      },
+      {
+        name: 'form 4',
+        published: true,
+        uuid: 'uuid4',
+        version: '1.0',
+      },
+    ];
+
+    const actualFilteredList = service.filterPublishedOpenmrsForms(forms);
+
+    expect(actualFilteredList.length).toEqual(3);
+    expect(actualFilteredList).toEqual(expectedFilteredList);
+  });
+
+  it('should add favourite property to forms list', () => {
+    const favourite = [
+      {
+        name: 'form 5',
+      },
+      {
+        name: 'form 3',
+      },
+    ];
+
+    const expectedfavouriteForms = [
+      {
+        name: 'form 1',
+        published: true,
+        uuid: 'uuid',
+        version: '1.0',
+        favourite: false,
+      },
+      {
+        name: 'form 2',
+        published: true,
+        uuid: 'uuid2',
+        version: '1.0',
+        favourite: false,
+      },
+      {
+        name: 'form 3',
+        published: false,
+        uuid: 'uuid3',
+        version: '1.0',
+        favourite: true,
+      },
+      {
+        name: 'form 4',
+        published: true,
+        uuid: 'uuid4',
+        version: '1.0',
+        favourite: false,
+      },
+      {
+        name: 'form 4',
+        published: false,
+        uuid: 'uuid4-unpublished',
+        version: '2.0',
+        favourite: false,
+      },
+      {
+        name: 'form 5',
+        published: false,
+        uuid: 'uuid5-unpublished',
+        version: '1.0',
+        favourite: true,
+      },
+    ];
+
+    const processFavouriteForms = service.processFavouriteForms(
+      forms,
+      favourite
     );
-    it('should sort array of forms given unsorted array and sorting metadata',
-        inject([FormListService], (formListService: FormListService) => {
-            const favourite = [{
-                name: 'form 5'
-            }, {
-                name: 'form 3'
-            }];
 
-            const defualtOrdering = [{
-                name: 'form 2'
-            }, {
-                name: 'form 3'
-            }];
+    expect(processFavouriteForms).toEqual(expectedfavouriteForms);
+  });
 
-            const expectedOrderForms = [{
-                name: 'form 5',
-                published: false,
-                uuid: 'uuid5-unpublished',
-                version: '1.0'
-            }, {
-                name: 'form 3',
-                published: false,
-                uuid: 'uuid3',
-                version: '1.0'
-            }, {
-                name: 'form 2',
-                published: true,
-                uuid: 'uuid2',
-                version: '1.0'
-            }, {
-                name: 'form 1',
-                published: true,
-                uuid: 'uuid',
-                version: '1.0'
-            }, {
-                name: 'form 4',
-                published: true,
-                uuid: 'uuid4',
-                version: '1.0'
-            }, {
-                name: 'form 4',
-                published: false,
-                uuid: 'uuid4-unpublished',
-                version: '2.0'
-            }];
+  it('should remove version information from a form name', () => {
+    // CASE 1: Perfect form name
+    const formName = ' some form name v1.00 '; // CASE 2: Imperfect version
+    const formName2 = ' some form name v1. '; // CASE 3: No version information
+    // the v intentionally put there for a certain test case
+    const formName3 = ' some form navme ';
+    expect(service.removeVersionInformation(formName)).toEqual(
+      'some form name'
+    );
+    expect(service.removeVersionInformation(formName2)).toEqual(
+      'some form name'
+    );
+    expect(service.removeVersionInformation(formName3)).toEqual(
+      'some form navme'
+    );
+  });
 
-            const actualOrderedForms = formListService.sortFormList(forms,
-                [favourite, defualtOrdering]);
-
-            expect(Array.isArray(actualOrderedForms)).toBeTruthy();
-            expect(actualOrderedForms[0]).toEqual(expectedOrderForms[0]);
-            expect(actualOrderedForms[1]).toEqual(expectedOrderForms[1]);
-            expect(actualOrderedForms[2]).toEqual(expectedOrderForms[2]);
-            expect(actualOrderedForms.length === expectedOrderForms.length).toBeTruthy();
-            expect(actualOrderedForms).toEqual(expectedOrderForms);
-
-        }));
-
-    xit('should filter out unpublished openmrs forms from a list',
-        inject([FormListService], (formListService: FormListService) => {
-            const expectedFilteredList = [{
-                name: 'form 1',
-                published: true,
-                uuid: 'uuid',
-                version: '1.0'
-            }, {
-                name: 'form 2',
-                published: true,
-                uuid: 'uuid2',
-                version: '1.0'
-            }, {
-                name: 'form 4',
-                published: true,
-                uuid: 'uuid4',
-                version: '1.0'
-            }];
-
-            const actualFilteredList = formListService.filterPublishedOpenmrsForms(forms);
-
-            expect(actualFilteredList.length === expectedFilteredList.length).toBeFalsy();
-
-        }));
-    it('should add favourite property to forms list',
-        inject([FormListService], (formListService: FormListService) => {
-            const favourite = [{
-                name: 'form 5'
-            }, {
-                name: 'form 3'
-            }];
-
-            const expectedfavouriteForms = [{
-                name: 'form 1',
-                published: true,
-                uuid: 'uuid',
-                version: '1.0',
-                favourite: false
-            }, {
-                name: 'form 2',
-                published: true,
-                uuid: 'uuid2',
-                version: '1.0',
-                favourite: false
-            }, {
-                name: 'form 3',
-                published: false,
-                uuid: 'uuid3',
-                version: '1.0',
-                favourite: true
-            }, {
-                name: 'form 4',
-                published: true,
-                uuid: 'uuid4',
-                version: '1.0',
-                favourite: false
-            }, {
-                name: 'form 4',
-                published: false,
-                uuid: 'uuid4-unpublished',
-                version: '2.0',
-                favourite: false
-            }, {
-                name: 'form 5',
-                published: false,
-                uuid: 'uuid5-unpublished',
-                version: '1.0',
-                favourite: true
-            }];
-
-            const processFavouriteForms = formListService.processFavouriteForms(forms, favourite);
-
-            expect(processFavouriteForms).toEqual(expectedfavouriteForms);
-        }));
-
-    xit('should fetch and process the final form list when getFormList is invoked',
-        async(inject([FormListService, FormOrderMetaDataService, FormsResourceService],
-            (formListService: FormListService,
-                formOrderMetaDataService: FormOrderMetaDataService,
-                formsResourceService: FormsResourceService) => {
-                const favourite = [{
-                    name: 'form 5'
-                }, {
-                    name: 'form 3'
-                }];
-
-                const defualtOrdering = [{
-                    name: 'form 2'
-                }, {
-                    name: 'form 3'
-                }];
-
-                const expectedFormsList = [
-                    { name: 'form 5', published: false, uuid: 'uuid5-unpublished', version: '1.0', favourite: true, display: 'form 5' },
-                    { name: 'form 3', published: false, uuid: 'uuid3', version: '1.0', favourite: true, display: 'form 3' },
-                    { name: 'form 2', published: true, uuid: 'uuid2', version: '1.0', favourite: false, display: 'form 2' },
-                    { name: 'form 1', published: true, uuid: 'uuid', version: '1.0', favourite: false, display: 'form 1' },
-                    { name: 'form 4', published: true, uuid: 'uuid4', version: '1.0', favourite: false, display: 'form 4' },
-                    { name: 'form 4', published: false, uuid: 'uuid4-unpublished', version: '2.0', favourite: false, display: 'form 4' }];
-
-                const favouriteFormsSpy = spyOn(formOrderMetaDataService,
-                    'getFavouriteForm').and.returnValue(
-                        favourite
-                    );
-                const defaultOrderSpy = spyOn(formOrderMetaDataService,
-                    'getDefaultFormOrder').and.returnValue(
-                        of(defualtOrdering)
-                    );
-                const formListSpy = spyOn(formsResourceService,
-                    'getForms').and.returnValue(
-                        of(forms)
-                    );
-                formListService.getFormList().subscribe((actualFormList) => {
-                    expect(actualFormList).toBeTruthy();
-                    expect(actualFormList).toEqual(expectedFormsList);
-                });
-
-            })));
-
-    it('should remove version information from a form name',
-        inject([FormListService], (formListService: FormListService) => {
-            // CASE 1: Perfect form name
-            const formName = ' some form name v1.00 '; // CASE 2: Imperfect version
-            const formName2 = ' some form name v1. '; // CASE 3: No version information
-            // the v intentionally put there for a certain test case
-            const formName3 = ' some form navme ';
-            expect(formListService.removeVersionInformation(formName)).toEqual('some form name');
-            expect(formListService.removeVersionInformation(formName2)).toEqual('some form name');
-            expect(formListService.removeVersionInformation(formName3)).toEqual('some form navme');
-        }));
-    it('should remove version information from an array of forms ',
-        inject([FormListService], (formListService: FormListService) => {
-            const formNames = [{
-                name: 'some'
-            }, {
-                name: 'form v1.0'
-            }];
-            const expectedFormNames = [{
-                name: 'some',
-                display: 'some'
-            }, {
-                name: 'form',
-                display: 'form v1.0'
-            }];
-            const actualFormNames = formListService.removeVersionInformationFromForms(formNames);
-            expect(expectedFormNames).toEqual(actualFormNames);
-        }));
+  it('should remove version information from an array of forms ', () => {
+    const formNames = [
+      {
+        name: 'some',
+      },
+      {
+        name: 'form v1.0',
+      },
+    ];
+    const expectedFormNames = [
+      {
+        name: 'some',
+        display: 'some',
+      },
+      {
+        name: 'form',
+        display: 'form v1.0',
+      },
+    ];
+    const actualFormNames = service.removeVersionInformationFromForms(
+      formNames
+    );
+    expect(expectedFormNames).toEqual(actualFormNames);
+  });
 });

--- a/src/app/patient-dashboard/common/forms/form-list.service.ts
+++ b/src/app/patient-dashboard/common/forms/form-list.service.ts
@@ -61,7 +61,7 @@ export class FormListService {
         }
         // comment out /*item.published && */ for all unretired forms (NOTE : ng-forms build)
         const publishedOpenmrsForms = _.filter(unsortArray, (item) => {
-          return !item.retired;
+          return item.published && !item.retired;
         });
 
         return publishedOpenmrsForms;


### PR DESCRIPTION
Restores check that ensures forms with `published` set to true are rendered. Also improves the test suite to catch this kind of bug in future.

Forgive the diff noise (due to linting).