### PR TITLE
Run prettier only on staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "lint-staged": {
     "*.{js,css,md,ts}": [
-      "prettier --write src/app",
-      "npm run lint ngx-amrs"
+      "prettier --write",
+      "ng lint ngx-amrs"
     ]
   },
   "private": true,


### PR DESCRIPTION
This PR:

- Modifies the Prettier script to run only on staged files.
- Modifies the lint command to call upon `ng lint` directly. 