### PR TITLE
POCAMRS-443: Revert county & subcounty form field logic

### DIFF
--- a/src/app/patient-creation/patient-creation.component.html
+++ b/src/app/patient-creation/patient-creation.component.html
@@ -11,6 +11,7 @@
               <span *ngIf="!givenName" class="required"> * </span></label
             >
             <input
+              id="givenName"
               type="text"
               class="form-control"
               [(ngModel)]="givenName"
@@ -30,6 +31,7 @@
           <div class="form-group">
             <label for="middleName">Middle Name (Optional)</label>
             <input
+              id="middleName"
               type="text"
               class="form-control"
               [(ngModel)]="middleName"
@@ -45,6 +47,7 @@
               <span *ngIf="!familyName" class="required"> * </span></label
             >
             <input
+              id="familyName"
               type="text"
               class="form-control"
               [(ngModel)]="familyName"
@@ -68,7 +71,12 @@
             <label for="gender"
               >Gender <span *ngIf="!gender" class="required"> * </span></label
             >
-            <select class="form-control" [(ngModel)]="gender" name="gender">
+            <select
+              id="gender"
+              class="form-control"
+              [(ngModel)]="gender"
+              name="gender"
+            >
               <option *ngFor="let opt of genderOptions" [value]="opt.val">
                 {{ opt.label }}
               </option>
@@ -87,6 +95,7 @@
               <span *ngIf="!occupation" class="required"> *</span></label
             >
             <select
+              id="occupation"
               class="form-control"
               [(ngModel)]="occupation"
               name="occupaton"
@@ -111,6 +120,7 @@
               ></label
             >
             <select
+              id="educationLevel"
               class="form-control"
               name="education"
               [(ngModel)]="patientHighestEducation"
@@ -124,7 +134,7 @@
             </select>
             <div *ngIf="errors && !patientHighestEducation" class="required">
               <span class="help-block" style="color: red"
-                >Highest Education Level</span
+                >Highest education level is required!</span
               >
             </div>
           </div>
@@ -169,7 +179,9 @@
       </div>
       <div class="row" *ngIf="patientExists">
         <div class="col-md-12 col-sm-12 col-lg-12 col-xs-12">
-          <button class="btn btn-primary" (click)="createPerson()">Next</button>
+          <button id="nextBtn" class="btn btn-primary" (click)="createPerson()">
+            Next
+          </button>
           <button
             *ngIf="
               (givenName && familyName && this.gender && this.birthDate) ||
@@ -177,6 +189,7 @@
               (middleName && patientHighestEducation)
             "
             type="button"
+            id="resetBtn"
             class="btn btn-danger pull-right"
             (click)="reset()"
           >
@@ -197,7 +210,7 @@
         <hr class="intro-divider patient-info-divider" />
         <div class="row">
           <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
-            <label
+            <label id="universalId"
               >Universal ID
               <span *ngIf="!patientIdentifier" class="required">
                 *
@@ -205,6 +218,7 @@
             >
             <span
               *ngIf="generate"
+              id="generateUniversalId"
               class="badge btn pull-right"
               (click)="generatePatientIdentifier()"
               >Generate</span
@@ -249,7 +263,11 @@
           </div>
           <div class="col-md-2 col-lg-2 col-sm-2 col-xs-2">
             <div class="form-group">
-              <button class="btn btn-primary" (click)="updateUniversal()">
+              <button
+                id="addUniversalId"
+                class="btn btn-primary"
+                (click)="updateUniversal()"
+              >
                 +
               </button>
             </div>
@@ -262,6 +280,7 @@
             <div class="form-group">
               <label class="control-label">Patient Identifier Type:</label>
               <select
+                id="identifierType"
                 class="form-control"
                 [ngModel]="patientIdentifierType"
                 (ngModelChange)="setIdentifierType($event)"
@@ -586,48 +605,40 @@
             <div class="form-group">
               <label for="address1" class="control-label">County</label>
               <select
+                id="address1"
                 class="form-control"
-                [ngModel]="address1"
-                (ngModelChange)="setCounty($event)"
-                name="address1"
+                [(ngModel)]="address1"
+                name="county"
+                (ngModelChange)="updateLocation($event)"
               >
-                <option
-                  *ngFor="let c of ampathLocations?.counties"
-                  [ngValue]="c.name"
+                <option *ngFor="let county of counties" [value]="county">
+                  {{ county }}
+                </option>
+              </select>
+              <div *ngIf="others">
+                <label for="address1" class="control-label"
+                  >County: Other (specify)</label
                 >
-                  {{ c.name }}
-                </option>
-              </select>
+                <input
+                  type="text"
+                  id="address1"
+                  class="form-control"
+                  [(ngModel)]="address1"
+                  name="address1"
+                />
+              </div>
             </div>
           </div>
           <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
             <div class="form-group">
-              <label for="address2" class="control-label">Sub County</label>
-              <select
+              <label for="address2" class="control-label">Subcounty</label>
+              <input
+                type="text"
+                id="address2"
                 class="form-control"
-                [ngModel]="address2"
-                (ngModelChange)="setSubCounty($event)"
+                [(ngModel)]="address2"
                 name="address2"
-              >
-                <option *ngFor="let subc of subcounties" [ngValue]="subc.name">
-                  {{ subc.name }}
-                </option>
-              </select>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
-            <div class="form-group">
-              <label for="address7" class="control-label">Ward</label>
-              <select
-                class="form-control"
-                [ngModel]="address7"
-                (ngModelChange)="setWard($event)"
-                name="address7"
-              >
-                <option *ngFor="let ward of wards" [ngValue]="ward">
-                  {{ ward }}
-                </option>
-              </select>
+              />
             </div>
           </div>
           <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
@@ -682,10 +693,15 @@
 
         <div class="row">
           <div class="col-md-12 col-sm-12 col-lg-12 col-xs-12">
-            <button class="btn btn-primary" (click)="createPatient()">
+            <button
+              id="saveBtn"
+              class="btn btn-primary"
+              (click)="createPatient()"
+            >
               Save
             </button>
             <button
+              id="cancelBtn"
               type="button"
               class="btn btn-danger pull-right"
               (click)="cancel()"

--- a/src/app/patient-creation/patient-creation.component.spec.ts
+++ b/src/app/patient-creation/patient-creation.component.spec.ts
@@ -1,17 +1,30 @@
-import { TestBed, inject, async } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+  async,
+  fakeAsync,
+  tick
+} from '@angular/core/testing';
 import { Router, ActivatedRoute } from '@angular/router';
-import { Location } from '@angular/common';
-import { SpyLocation } from '@angular/common/testing';
+import { FormsModule } from '@angular/forms';
+
+import { of } from 'rxjs';
 import { MatSnackBar } from '@angular/material';
+import { Storage } from '@ionic/storage';
+import { CacheModule } from 'ionic-cache/dist/cache.module';
+import { ModalModule } from 'ngx-bootstrap';
+import { ToastrModule } from 'ngx-toastr';
+import { NgSelectModule } from '@ng-select/ng-select';
+import { NgxPaginationModule } from 'ngx-pagination';
+import { BsModalService } from 'ngx-bootstrap/modal';
+import { DateTimePickerModule } from 'ngx-openmrs-formentry';
 
 import { AppFeatureAnalytics } from '../shared/app-analytics/app-feature-analytics.service';
 import { FakeAppFeatureAnalytics } from '../shared/app-analytics/app-feature-analytcis.mock';
 import { LocalStorageService } from '../utils/local-storage.service';
 import { PatientCreationComponent } from './patient-creation.component';
 import { PatientCreationService } from './patient-creation.service';
-import { Observable } from 'rxjs';
-import { BsModalService } from 'ngx-bootstrap/modal';
-
 import { PatientCreationResourceService } from '../openmrs-api/patient-creation-resource.service';
 import { LocationResourceService } from '../openmrs-api/location-resource.service';
 import { PatientIdentifierTypeResService } from '../openmrs-api/patient-identifierTypes-resource.service';
@@ -20,34 +33,144 @@ import { PatientResourceService } from '../openmrs-api/patient-resource.service'
 import { UserService } from '../openmrs-api/user.service';
 import { SessionStorageService } from '../utils/session-storage.service';
 import { DataCacheService } from '../shared/services/data-cache.service';
-import { CacheModule } from 'ionic-cache/dist/cache.module';
-import { Storage } from '@ionic/storage';
-import { ModalModule } from 'ngx-bootstrap';
-import { AppSettingsModule } from '../app-settings/app-settings.module';
-import { ToastrModule } from 'ngx-toastr';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { AppSettingsService } from '../app-settings/app-settings.service';
 import { ConceptResourceService } from './../openmrs-api/concept-resource.service';
 import { PatientRelationshipTypeService } from '../patient-dashboard/common/patient-relationships/patient-relation-type.service';
-import { PatientRelationshipTypeResourceService } from '../openmrs-api/patient-relationship-type-resource.service';
 import { PatientEducationService } from '../etl-api/patient-education.service';
 
+const testLocations = [
+  {
+    name: 'Test A',
+    stateProvince: 'Foo',
+    uuid: 'uuid1'
+  },
+  {
+    name: 'Test B',
+    stateProvince: 'Bar',
+    uuid: 'uuid2'
+  }
+];
+
+const testConcept = {
+  answers: [
+    { display: 'TEACHER', uuid: 'teacher-uuid' },
+    { display: 'CASUAL WORKER', uuid: 'casual-worker-uuid' },
+    { display: 'HEALTH WORKER', uuid: 'health-worker-uuid' }
+  ],
+  name: {
+    display: 'OCCUPATION',
+    uuid: 'test-occupation-concept-uuid'
+  },
+  uuid: 'test-uuid'
+};
+
+const testEducationLevels = [
+  {
+    uuid: 'a899e0ac-1350-11df-a1f1-0026b9348838',
+    display: 'NONE'
+  },
+  {
+    uuid: 'a8afe910-1350-11df-a1f1-0026b9348838',
+    display: 'PRIMARY SCHOOL'
+  },
+  {
+    uuid: 'a8afe9d8-1350-11df-a1f1-0026b9348838',
+    display: 'SECONDARY SCHOOL'
+  },
+  {
+    uuid: 'a89e4728-1350-11df-a1f1-0026b9348838',
+    display: 'UNIVERSITY'
+  }
+];
+
+const testIdentifierTypes = [
+  { uuid: 'uuid1', name: 'A test ID' },
+  { uuid: 'uuid2', name: 'A sophisticated test ID' },
+  { uuid: 'uuid3', name: 'An everyday test ID' }
+];
+
+const testRelationshipTypes = [
+  { uuid: 'uuid1', aIsToB: 'Parent', bIsToA: 'Child', display: 'Parent/Child' }
+];
+
+const conceptResourceServiceStub = {
+  getConceptByUuid: (uuid) => of(testConcept)
+};
+
+const locationResourceServiceStub = {
+  getLocations: () => of(testLocations)
+};
+
+const patientEducationServiceStub = {
+  getEducationLevels: () => testEducationLevels
+};
+
+const patientIdentifierTypeServiceStub = {
+  getPatientIdentifierTypes: () => of(testIdentifierTypes)
+};
+
+const patientRelationshipTypeServiceStub = {
+  getRelationshipTypes: () => of(testRelationshipTypes)
+};
+
+const patientCreationServiceStub = {
+  getpatientResults: () => of([]),
+  generateIdentifier: (userId) => {
+    return of({ identifier: '123456789-0' });
+  },
+  patientResults: () => of([]),
+  searchPatient: (searchString) => of([])
+};
+
+const userServiceStub = {
+  getLoggedInUser: () => {
+    const openmrsModel = {
+      systemId: 'test-12345'
+    };
+    return {
+      display: 'Test User',
+      openmrsModel: openmrsModel
+    };
+  }
+};
+
 describe('Component: Patient Creation Unit Tests', () => {
-  let fakeAppFeatureAnalytics: AppFeatureAnalytics, component;
+  let component: PatientCreationComponent;
+  let fixture: ComponentFixture<PatientCreationComponent>;
+  let debugElement: DebugElement;
+  let nativeElement: HTMLElement;
+  let patientCreationResourceService: PatientCreationResourceService;
+  let savePatientSpy: jasmine.Spy;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         ModalModule.forRoot(),
         CacheModule.forRoot(),
         ToastrModule.forRoot(),
-        HttpClientTestingModule
+        FormsModule,
+        DateTimePickerModule,
+        HttpClientTestingModule,
+        NgxPaginationModule,
+        NgSelectModule
       ],
+      declarations: [PatientCreationComponent],
       providers: [
+        MatSnackBar,
+        AppSettingsService,
+        BsModalService,
+        DataCacheService,
         FakeAppFeatureAnalytics,
-        {
-          provide: AppFeatureAnalytics,
-          useClass: FakeAppFeatureAnalytics
-        },
+        LocalStorageService,
+        PatientCreationComponent,
+        PatientCreationService,
+        PatientCreationResourceService,
+        PatientIdentifierTypeResService,
+        PatientIdentifierService,
+        PatientResourceService,
+        SessionStorageService,
+        { provide: AppFeatureAnalytics, useClass: FakeAppFeatureAnalytics },
         {
           provide: Router
         },
@@ -57,74 +180,261 @@ describe('Component: Patient Creation Unit Tests', () => {
         {
           provide: Storage
         },
-        AppSettingsService,
-        LocalStorageService,
-        PatientCreationComponent,
-        MatSnackBar,
-        BsModalService,
-        PatientCreationService,
-        PatientCreationResourceService,
-        PatientIdentifierTypeResService,
-        SessionStorageService,
-        PatientIdentifierService,
-        LocationResourceService,
-        PatientResourceService,
-        UserService,
-        DataCacheService,
-        ConceptResourceService,
-        PatientRelationshipTypeService,
-        PatientRelationshipTypeResourceService,
-        PatientEducationService
+        {
+          provide: ConceptResourceService,
+          useValue: conceptResourceServiceStub
+        },
+        {
+          provide: LocationResourceService,
+          useValue: locationResourceServiceStub
+        },
+        {
+          provide: PatientCreationService,
+          useValue: patientCreationServiceStub
+        },
+        {
+          provide: PatientEducationService,
+          useValue: patientEducationServiceStub
+        },
+        {
+          provide: PatientIdentifierTypeResService,
+          useValue: patientIdentifierTypeServiceStub
+        },
+        {
+          provide: PatientRelationshipTypeService,
+          useValue: patientRelationshipTypeServiceStub
+        },
+        {
+          provide: UserService,
+          useValue: userServiceStub
+        }
       ]
-    });
-
-    fakeAppFeatureAnalytics = TestBed.get(AppFeatureAnalytics);
-    component = TestBed.get(PatientCreationComponent);
+    }).compileComponents();
   }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PatientCreationComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+    nativeElement = debugElement.nativeElement;
+    patientCreationResourceService = TestBed.get(
+      PatientCreationResourceService
+    );
+  });
 
   afterEach(() => {
     TestBed.resetTestingModule();
   });
 
-  it('should instantiate the component', (done) => {
-    expect(component).toBeTruthy();
-    done();
+  describe('Init', () => {
+    it('should instantiate the component', () => {
+      fixture.detectChanges();
+      expect(component).toBeDefined();
+      expect(
+        nativeElement.querySelector('.component-wrapper h2').textContent
+      ).toMatch(/Patient Registration/);
+      const formFields = nativeElement.querySelectorAll(
+        '.col-md-4 .form-group'
+      );
+      expect(formFields.length).toEqual(7, '7 initial form fields');
+      expect(formFields[0].textContent).toMatch(/First Name/);
+      expect(formFields[1].textContent).toMatch(/Middle Name \(Optional\)/);
+      expect(formFields[2].textContent).toMatch(/Family Name/);
+      expect(formFields[3].textContent).toMatch(/Gender/);
+      expect(formFields[4].textContent).toMatch(/Occupation/);
+      expect(formFields[5].textContent).toMatch(/Highest Education Level/);
+      expect(formFields[6].textContent).toMatch(/Age/);
+    });
   });
-  it('form should be valid', () => {
-    expect(component.identifierValidity).toBeFalsy();
-  });
-  it('form should be filled with age less than 116 years ', () => {
-    expect(component.birthError).toBeFalsy();
-  });
-  // it('should return the correct age ',()=>{
-  //   const dateString = "2010-08-28T11:43:41+03:00";
-  //   component.today = new Date(2019,08,28);
-  //   const age = component.getAge(dateString);
-  //   expect(age).toBe(9);
-  // });
 
-  it('should set the correct identifier type ', () => {
-    const mockIdentifierType = {
-      label: 'MTCT Plus ID',
-      val: '58a46d20-1359-11df-a1f1-0026b9348838'
-    };
-    component.setIdentifierType(mockIdentifierType);
-    const identifierType = component.patientIdentifierType;
-    expect(JSON.stringify(identifierType)).toBe(
-      JSON.stringify(mockIdentifierType)
-    );
+  describe('Form actions ', () => {
+    let firstNameInput: HTMLInputElement;
+    let middleNameInput: HTMLInputElement;
+    let familyNameInput: HTMLInputElement;
+    let genderSelect: HTMLSelectElement;
+    let occupationSelect: HTMLSelectElement;
+    let educationLevelSelect: HTMLSelectElement;
+
+    beforeEach(async(() => {
+      fixture.detectChanges();
+      firstNameInput = fixture.nativeElement.querySelector('input#givenName');
+      middleNameInput = fixture.nativeElement.querySelector('input#middleName');
+      familyNameInput = fixture.nativeElement.querySelector('input#familyName');
+      genderSelect = fixture.nativeElement.querySelector('select#gender');
+      occupationSelect = fixture.nativeElement.querySelector(
+        'select#occupation'
+      );
+      educationLevelSelect = fixture.nativeElement.querySelector(
+        'select#educationLevel'
+      );
+
+      firstNameInput.value = 'Test';
+      middleNameInput.value = 'Patient';
+      familyNameInput.value = 'Name';
+      genderSelect.value = genderSelect.options[1].value;
+      occupationSelect.value = occupationSelect.options[1].value;
+      educationLevelSelect.value = educationLevelSelect.options[1].value;
+
+      firstNameInput.dispatchEvent(new Event('input'));
+      middleNameInput.dispatchEvent(new Event('input'));
+      familyNameInput.dispatchEvent(new Event('input'));
+      genderSelect.dispatchEvent(new Event('change'));
+      occupationSelect.dispatchEvent(new Event('change'));
+      educationLevelSelect.dispatchEvent(new Event('change'));
+    }));
+
+    it('should reset the demographics form fields when reset button is clicked', fakeAsync(() => {
+      expect(component.givenName).toEqual('Test');
+      expect(component.middleName).toEqual('Patient');
+      expect(component.familyName).toEqual('Name');
+      expect(component.gender).toEqual('M');
+      expect(component.errors).toEqual(false);
+
+      tickAndDetectChanges(fixture);
+
+      const resetBtn: HTMLButtonElement = nativeElement.querySelector(
+        'button#resetBtn'
+      );
+      click(resetBtn);
+
+      expect(component.givenName).toEqual('');
+      expect(component.familyName).toEqual('');
+      expect(component.middleName).toEqual('');
+      expect(component.gender).toEqual('');
+      expect(component.birthDate).toEqual('');
+      expect(component.ageEstimate).toEqual(null);
+      expect(component.errors).toEqual(false);
+    }));
+
+    it('should submit the form when the save button is clicked after filling the form', fakeAsync(() => {
+      savePatientSpy = spyOn(
+        patientCreationResourceService,
+        'savePatient'
+      ).and.callFake(() => {
+        return of({
+          person: {
+            display: '123456789-0 - Yet Another Test Patient'
+          }
+        });
+      });
+
+      component.updateBirthDate(new Date('01-01-1991'));
+      const nextBtn: HTMLButtonElement = nativeElement.querySelector(
+        'button#nextBtn'
+      );
+      click(nextBtn);
+      tickAndDetectChanges(fixture);
+
+      /*
+       * With demographics filled in, assert that fields from the Identifiers
+       * section and the form action buttons are rendered.
+       */
+      const universalIdLabel: HTMLElement = nativeElement.querySelector(
+        '#universalId'
+      );
+      const identifierTypeSelect: HTMLSelectElement = nativeElement.querySelector(
+        'select#identifierType'
+      );
+      const cancelBtn: HTMLButtonElement = nativeElement.querySelector(
+        'button#cancelBtn'
+      );
+      const saveBtn: HTMLButtonElement = nativeElement.querySelector(
+        'button#saveBtn'
+      );
+      const generateUniversalIdEl: HTMLSpanElement = nativeElement.querySelector(
+        'span#generateUniversalId'
+      );
+      const addUniversalIdBtn: HTMLButtonElement = nativeElement.querySelector(
+        'button#addUniversalId'
+      );
+      const countySelect: HTMLSelectElement = nativeElement.querySelector(
+        'select#address1'
+      );
+      const subcountyInput: HTMLInputElement = nativeElement.querySelector(
+        'input#address2'
+      );
+
+      expect(universalIdLabel).toBeDefined();
+      expect(identifierTypeSelect).toBeDefined();
+      expect(cancelBtn).toBeDefined();
+      expect(saveBtn).toBeDefined();
+
+      click(generateUniversalIdEl);
+      click(addUniversalIdBtn);
+
+      identifierTypeSelect.value = identifierTypeSelect.options[2].value;
+      identifierTypeSelect.dispatchEvent(new Event('change'));
+
+      const identifierLocationSelect: HTMLSelectElement = nativeElement.querySelector(
+        'ng-select'
+      );
+      identifierLocationSelect.value = 'Test';
+      identifierLocationSelect.dispatchEvent(new Event('input'));
+
+      component.selectedLocation = testLocations[0].name;
+      component.identifierLocation = 'uuid2';
+
+      countySelect.value = countySelect.options[0].value;
+      countySelect.dispatchEvent(new Event('change'));
+
+      subcountyInput.value = 'Quux';
+      subcountyInput.dispatchEvent(new Event('input'));
+
+      click(saveBtn);
+      tick(500);
+
+      expect(component.errors).toBeFalsy('no errors');
+      expect(component.errorAlerts.length).toEqual(0);
+      expect(savePatientSpy).toHaveBeenCalledTimes(1);
+      expect(savePatientSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          person: jasmine.objectContaining({
+            names: jasmine.arrayContaining([
+              jasmine.objectContaining({
+                givenName: 'Test',
+                middleName: 'Patient',
+                familyName: 'Name'
+              })
+            ]),
+            gender: 'M',
+            attributes: jasmine.arrayContaining([
+              {
+                value: 'casual-worker-uuid',
+                attributeType: '9e86409f-9c20-42d0-aeb3-f29a4ca0a7a0'
+              }
+            ]),
+            addresses: jasmine.arrayContaining([
+              jasmine.objectContaining({
+                address1: 'Foo', // county
+                address2: 'Quux' // subcounty
+              })
+            ])
+          })
+        })
+      );
+    }));
   });
-  it('should set the preffered identifier ', () => {
-    const mockPreferedIdentifierType = {
-      identifier: '7364732',
-      identifierType: '58a48706-1359-11df-a1f1-0026b9348838',
-      identifierTypeName: 'MTRH CARE Number'
-    };
-    component.setPreferred(mockPreferedIdentifierType);
-    const preferedidentifierType = component.preferredIdentifier;
-    expect(JSON.stringify(preferedidentifierType)).toBe(
-      JSON.stringify(mockPreferedIdentifierType)
-    );
-  });
-  it('should filter patients ', () => {});
 });
+
+/** Button events to pass to `DebugElement.triggerEventHandler` for RouterLink event handler */
+const ButtonClickEvents = {
+  left: { button: 0 },
+  right: { button: 2 }
+};
+
+/** Simulate element click. Defaults to mouse left-button click event. */
+function click(
+  el: DebugElement | HTMLElement,
+  eventObj: any = ButtonClickEvents.left
+): void {
+  if (el instanceof HTMLElement) {
+    el.click();
+  } else {
+    el.triggerEventHandler('click', eventObj);
+  }
+}
+
+function tickAndDetectChanges(fixture: ComponentFixture<any>) {
+  fixture.detectChanges();
+  tick();
+}

--- a/src/app/patient-creation/patient-creation.component.spec.ts
+++ b/src/app/patient-creation/patient-creation.component.spec.ts
@@ -6,6 +6,7 @@ import {
   fakeAsync,
   tick
 } from '@angular/core/testing';
+import { click, tickAndDetectChanges } from '../test-helpers';
 import { Router, ActivatedRoute } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 
@@ -415,26 +416,3 @@ describe('Component: Patient Creation Unit Tests', () => {
     }));
   });
 });
-
-/** Button events to pass to `DebugElement.triggerEventHandler` for RouterLink event handler */
-const ButtonClickEvents = {
-  left: { button: 0 },
-  right: { button: 2 }
-};
-
-/** Simulate element click. Defaults to mouse left-button click event. */
-function click(
-  el: DebugElement | HTMLElement,
-  eventObj: any = ButtonClickEvents.left
-): void {
-  if (el instanceof HTMLElement) {
-    el.click();
-  } else {
-    el.triggerEventHandler('click', eventObj);
-  }
-}
-
-function tickAndDetectChanges(fixture: ComponentFixture<any>) {
-  fixture.detectChanges();
-  tick();
-}

--- a/src/app/patient-creation/patient-creation.component.ts
+++ b/src/app/patient-creation/patient-creation.component.ts
@@ -830,13 +830,12 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
         (locations: any[]) => {
           this.locations = [];
           const counties = [];
-          // tslint:disable-next-line:prefer-for-of
-          for (let i = 0; i < locations.length; i++) {
+          for (const location of locations) {
             this.locations.push({
-              label: locations[i].name,
-              value: locations[i].uuid
+              label: location.name,
+              value: location.uuid
             });
-            counties.push(locations[i].stateProvince);
+            counties.push(location.stateProvince);
           }
           this.counties = _.uniq(counties);
           this.counties = _.remove(this.counties, (n) => {

--- a/src/app/patient-creation/patient-creation.component.ts
+++ b/src/app/patient-creation/patient-creation.component.ts
@@ -703,7 +703,7 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
     this.errors = false;
   }
 
-  public ngOnDestroy(): void {
+  public ngOnDestroy() {
     this.subscriptions.map((sub) => sub.unsubscribe);
   }
 
@@ -746,7 +746,7 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
       });
   }
 
-  private checkAdded() {
+  private checkAdded(): boolean {
     let found;
     // tslint:disable-next-line:prefer-for-of
     for (let i = 0; i < this.identifiers.length; i++) {
@@ -762,7 +762,7 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
     }
   }
 
-  private checkUniversal() {
+  private checkUniversal(): boolean {
     let found = false;
     // tslint:disable-next-line:prefer-for-of
     for (let i = 0; i < this.identifiers.length; i++) {
@@ -822,7 +822,7 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
       );
   }
 
-  private getLocations(): void {
+  private getLocations() {
     const locationResourceServiceSub = this.locationResourceService
       .getLocations()
       .pipe(take(1))
@@ -861,7 +861,7 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
     this.subscriptions.push(getLocationsSubscription);
   }
 
-  private validateFormFields(patientIdentifier) {
+  private validateFormFields(patientIdentifier): boolean {
     if (this.isNullOrUndefined(patientIdentifier)) {
       this.setErroMessage('Patient identifier is required!');
       return false;
@@ -870,7 +870,7 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
     return true;
   }
 
-  private isNullOrUndefined(val) {
+  private isNullOrUndefined(val): boolean {
     return (
       val === null ||
       val === undefined ||
@@ -934,12 +934,11 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
     this.errorMessage = message;
   }
 
-  private calculateAge(age) {
+  private calculateAge(age): string {
     const baseYear = 1970;
     const thisYear = new Date().getFullYear();
-    let date;
-
     const yearDiff = thisYear - age;
+    let date;
 
     if (yearDiff < baseYear) {
       date = (baseYear - yearDiff) * -31556926000;
@@ -948,7 +947,6 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
     }
 
     const estimateDate = new Date(date).toISOString();
-
     return estimateDate;
   }
 
@@ -972,7 +970,7 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
     this.address7 = event;
   }
 
-  public getRelationshipTypes(): void {
+  public getRelationshipTypes() {
     const request = this.patientRelationshipTypeService.getRelationshipTypes();
     request.subscribe(
       (relationshipTypes) => {

--- a/src/app/patient-dashboard/common/patient-info/address.component.html
+++ b/src/app/patient-dashboard/common/patient-info/address.component.html
@@ -9,8 +9,8 @@
     <tbody>
       <tr>
         <td><strong>County : </strong> {{ address1 }}</td>
-        <td><strong>Sub County : </strong>{{ address2 }}</td>
-        <td><strong>Ward : </strong>{{ address7 }}</td>
+        <td><strong>Subcounty : </strong>{{ address2 }}</td>
+        <!-- <td><strong>Ward : </strong>{{ address7 }}</td> -->
       </tr>
       <tr>
         <td><strong>Estate/Nearest Center : </strong>{{ address3 }}</td>

--- a/src/app/patient-dashboard/common/patient-info/edit-address.component.html
+++ b/src/app/patient-dashboard/common/patient-info/edit-address.component.html
@@ -28,51 +28,25 @@
           <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
             <div class="form-group">
               <label for="address1" class="control-label">County</label>
-              <select
+              <input
+                type="text"
+                id="address1"
                 class="form-control"
-                [ngModel]="address1"
-                (ngModelChange)="setCounty($event)"
+                [(ngModel)]="address1"
                 name="address1"
-              >
-                <option
-                  *ngFor="let c of locations?.counties"
-                  [ngValue]="c.name"
-                >
-                  {{ c.name }}
-                </option>
-              </select>
-              <!-- <input type="text" id="address1" class="form-control" [(ngModel)]="address1" name="address1"> -->
+              />
             </div>
           </div>
           <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
             <div class="form-group">
-              <label for="address2" class="control-label">Sub County</label>
-              <select
+              <label for="address2" class="control-label">Subcounty</label>
+              <input
+                type="text"
+                id="address2"
                 class="form-control"
-                [ngModel]="address2"
-                (ngModelChange)="setSubCounty($event)"
+                [(ngModel)]="address2"
                 name="address2"
-              >
-                <option *ngFor="let subc of subcounties" [ngValue]="subc.name">
-                  {{ subc.name }}
-                </option>
-              </select>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
-            <div class="form-group">
-              <label for="address7" class="control-label">Ward</label>
-              <select
-                class="form-control"
-                [ngModel]="address7"
-                (ngModelChange)="setWard($event)"
-                name="address7"
-              >
-                <option *ngFor="let ward of wards" [ngValue]="ward">
-                  {{ ward }}
-                </option>
-              </select>
-              <!-- <input type="text" id="address7" class="form-control" [(ngModel)]="address7" name="address7"> -->
+              />
             </div>
           </div>
           <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">

--- a/src/app/patient-dashboard/common/patient-info/edit-address.component.html
+++ b/src/app/patient-dashboard/common/patient-info/edit-address.component.html
@@ -31,6 +31,31 @@
               <label id="county" for="address1" class="control-label"
                 >County</label
               >
+              <select
+                id="address1"
+                class="form-control"
+                [(ngModel)]="address1"
+                name="county"
+                (ngModelChange)="updateLocation($event)"
+              >
+                <option
+                  *ngFor="let county of counties"
+                  [selected]="county === address1"
+                  [value]="county"
+                >
+                  {{ county }}
+                </option>
+              </select>
+            </div>
+          </div>
+          <div
+            *ngIf="nonCodedCounty"
+            class="col-md-6 col-lg-6 col-sm-6 col-xs-6"
+          >
+            <div class="form-group">
+              <label for="address1" class="control-label"
+                >County: Other (specify)</label
+              >
               <input
                 type="text"
                 id="address1"

--- a/src/app/patient-dashboard/common/patient-info/edit-address.component.html
+++ b/src/app/patient-dashboard/common/patient-info/edit-address.component.html
@@ -8,6 +8,7 @@
       <div class="row">
         <div class="col-md-12 col-sm-12 col-lg-12 col-xs-12">
           <div
+            id="successMsg"
             class="alert alert-success"
             *ngIf="showSuccessAlert"
             style="margin-top: 10px"
@@ -27,7 +28,9 @@
         <form name="personForm">
           <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
             <div class="form-group">
-              <label for="address1" class="control-label">County</label>
+              <label id="county" for="address1" class="control-label"
+                >County</label
+              >
               <input
                 type="text"
                 id="address1"
@@ -39,7 +42,9 @@
           </div>
           <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
             <div class="form-group">
-              <label for="address2" class="control-label">Subcounty</label>
+              <label id="subcounty" for="address2" class="control-label"
+                >Subcounty</label
+              >
               <input
                 type="text"
                 id="address2"
@@ -51,7 +56,7 @@
           </div>
           <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
             <div class="form-group">
-              <label for="address3" class="control-label"
+              <label id="estate" for="address3" class="control-label"
                 >Estate/Nearest Center</label
               >
               <input
@@ -65,7 +70,9 @@
           </div>
           <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
             <div class="form-group">
-              <label for="cityVillage" class="control-label">City</label>
+              <label id="city" for="cityVillage" class="control-label"
+                >City</label
+              >
               <input
                 type="text"
                 id="cityVillage"
@@ -84,6 +91,7 @@
     style="padding-top: 15px"
   >
     <button
+      id="saveBtn"
       class="btn btn-primary"
       type="button"
       (click)="updatePersonAddress()"
@@ -91,6 +99,7 @@
       <span>Save</span>
     </button>
     <button
+      id="cancelBtn"
       class="btn btn-danger pull-right"
       type="button"
       (click)="dismissDialog()"

--- a/src/app/patient-dashboard/common/patient-info/edit-address.component.spec.ts
+++ b/src/app/patient-dashboard/common/patient-info/edit-address.component.spec.ts
@@ -1,4 +1,12 @@
-import { TestBed, inject, async } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { click } from '../../../test-helpers';
+
+import { DialogModule } from 'primeng/primeng';
+import { BehaviorSubject, of } from 'rxjs';
 
 import { AppFeatureAnalytics } from '../../../shared/app-analytics/app-feature-analytics.service';
 import { FakeAppFeatureAnalytics } from '../../../shared/app-analytics/app-feature-analytcis.mock';
@@ -16,91 +24,239 @@ import { ProgramService } from '../../programs/program.service';
 import { ProgramResourceService } from '../../../openmrs-api/program-resource.service';
 import { ProgramWorkFlowResourceService } from '../../../openmrs-api/program-workflow-resource.service';
 import { ProgramWorkFlowStateResourceService } from '../../../openmrs-api/program-workflow-state-resource.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { LocationResourceService } from 'src/app/openmrs-api/location-resource.service';
+import { LocationResourceService } from '../../../openmrs-api/location-resource.service';
+import { Patient } from '../../../models/patient.model';
 
-describe('Component: EditAddress Unit Tests', () => {
-  let personResourceService: PersonResourceService,
-    patientResourceService: PatientResourceService,
-    fakeAppFeatureAnalytics: AppFeatureAnalytics,
-    component;
+const testLocations = [
+  {
+    name: 'Test A',
+    uuid: 'uuid1'
+  },
+  {
+    name: 'Test B',
+    uuid: 'uuid2'
+  }
+];
 
-  beforeEach(() => {
+const testPatient = new Patient({
+  display: '0123456789-0 - Yet Another Test Patient',
+  person: {
+    preferredAddress: {
+      address1: 'Foo',
+      address2: 'Bar',
+      cityVillage: 'Quux',
+      country: 'Fakekistan',
+      uuid: 'test-uuid'
+    },
+    uuid: 'test-person-uuid'
+  }
+});
+
+const testPersonAddressPayload = {
+  address1: 'Municipio',
+  address2: 'Subcampo',
+  address3: 'Fazenda',
+  cityVillage: 'Cidade',
+  latitude: undefined,
+  longitude: undefined,
+  uuid: 'test-uuid',
+  address7: undefined
+};
+
+const testResponse = {};
+
+const locationResourceServiceStub = {
+  getLocations: () => of(testLocations)
+};
+
+const personResourceServiceStub = {
+  saveUpdatePerson: (personUuid, personAddressPayload) => {
+    return of(testResponse);
+  }
+};
+
+class PatientServiceStub {
+  public patient: Patient;
+  public currentlyLoadedPatient: BehaviorSubject<Patient> = new BehaviorSubject(
+    null
+  );
+
+  reloadCurrentPatient() {}
+
+  constructor(patient) {
+    this.currentlyLoadedPatient.next(patient);
+  }
+}
+
+describe('Component: EditAddressComponent Unit Tests', () => {
+  let component: EditAddressComponent;
+  let fixture: ComponentFixture<EditAddressComponent>;
+  let debugElement: DebugElement;
+  let nativeElement: HTMLElement;
+  let dialogHeader: HTMLElement;
+  let saveBtn: HTMLButtonElement;
+  let personResourceService: PersonResourceService;
+  let saveUpdatePersonSpy: jasmine.Spy;
+
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [
+        BrowserAnimationsModule,
+        DialogModule,
+        FormsModule,
+        HttpClientTestingModule
+      ],
+      declarations: [EditAddressComponent],
       providers: [
+        AppSettingsService,
+        EncounterResourceService,
         FakeAppFeatureAnalytics,
-        PatientService,
+        LocalStorageService,
+        PatientResourceService,
+        PatientProgramService,
         ProgramService,
         ProgramResourceService,
-        PatientProgramService,
-        RoutesProviderService,
         ProgramEnrollmentResourceService,
         ProgramWorkFlowResourceService,
         ProgramWorkFlowStateResourceService,
-        EncounterResourceService,
-        EditAddressComponent,
+        RoutesProviderService,
         {
           provide: AppFeatureAnalytics,
           useClass: FakeAppFeatureAnalytics
         },
         {
-          provide: PersonResourceService
+          provide: LocationResourceService,
+          useValue: locationResourceServiceStub
         },
         {
-          provide: PatientResourceService
+          provide: PatientService,
+          useFactory: () => new PatientServiceStub(testPatient)
         },
         {
-          provide: LocationResourceService
-        },
-        AppSettingsService,
-        LocalStorageService
+          provide: PersonResourceService,
+          useValue: personResourceServiceStub
+        }
       ]
-    });
+    }).compileComponents();
+  }));
 
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(EditAddressComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+    nativeElement = debugElement.nativeElement;
     personResourceService = TestBed.get(PersonResourceService);
-    patientResourceService = TestBed.get(PersonResourceService);
-    fakeAppFeatureAnalytics = TestBed.get(AppFeatureAnalytics);
-    component = TestBed.get(EditAddressComponent);
-  });
-  const personAddressPayload = {
-    addresses: [
-      {
-        address1: '111',
-        address2: '3322',
-        address3: '1228',
-        cityVillage: 'eldoret',
-        stateProvince: 'rift'
-      }
-    ]
-  };
+
+    component.showDialog();
+    fixture.detectChanges();
+    saveBtn = nativeElement.querySelector('button#saveBtn');
+  }));
 
   afterEach(() => {
     TestBed.resetTestingModule();
   });
 
-  it('should instantiate the component', (done) => {
-    expect(component).toBeTruthy();
-    done();
+  it('should instantiate the component', () => {
+    const countyLabel: HTMLLabelElement = nativeElement.querySelector(
+      'label#county'
+    );
+    const subcountyLabel: HTMLLabelElement = nativeElement.querySelector(
+      'label#subcounty'
+    );
+    const estateLabel: HTMLLabelElement = nativeElement.querySelector(
+      'label#estate'
+    );
+    const cityLabel: HTMLLabelElement = nativeElement.querySelector(
+      'label#city'
+    );
+    const cancelBtn: HTMLButtonElement = nativeElement.querySelector(
+      'button#cancelBtn'
+    );
+
+    expect(component).toBeDefined();
+    expect(component.display).toEqual(true);
+    expect(component.patient).toBeDefined();
+
+    dialogHeader = nativeElement.querySelector('.ui-dialog-title');
+
+    expect(dialogHeader.textContent).toContain('Edit Address');
+    expect(countyLabel.textContent).toEqual('County');
+    expect(subcountyLabel.textContent).toEqual('Subcounty');
+    expect(estateLabel.textContent).toMatch(/Estate\/Nearest Center/);
+    expect(cityLabel.textContent).toEqual('City');
+    expect(cancelBtn.textContent).toEqual('Cancel');
+    expect(saveBtn.textContent).toEqual('Save');
   });
-  it('should have  the required functions defined and callable', (done) => {
-    spyOn(component, 'getPatient').and.callFake((err, data) => {});
-    component.getPatient((err, data) => {});
-    expect(component.getPatient).toHaveBeenCalled();
-    done();
-    spyOn(component, 'updatePersonAddress').and.callFake((err, data) => {});
-    component.updatePersonAddress((err, data) => {});
-    expect(component.updatePersonAddress).toHaveBeenCalled();
-    done();
-  });
-  it('should have required properties', (done) => {
-    expect(component.address1).toBeUndefined();
-    expect(component.address1).toBeUndefined();
-    expect(component.address2).toBeUndefined();
-    expect(component.address3).toBeUndefined();
-    expect(component.cityVillage).toBeUndefined();
-    expect(component.stateProvince).toBeUndefined();
-    expect(component.preferredAddressUuid).toBeUndefined();
-    done();
-  });
+
+  it('should submit the form when the save button is clicked after filling the form', async(() => {
+    saveUpdatePersonSpy = spyOn(
+      personResourceService,
+      'saveUpdatePerson'
+    ).and.callThrough();
+
+    // Set new values for county, subcounty, estate and city
+    const countyInput: HTMLInputElement = nativeElement.querySelector(
+      'input#address1'
+    );
+    const subcountyInput: HTMLInputElement = nativeElement.querySelector(
+      'input#address2'
+    );
+    const estateInput: HTMLInputElement = nativeElement.querySelector(
+      'input#address3'
+    );
+    const cityInput: HTMLInputElement = nativeElement.querySelector(
+      'input#cityVillage'
+    );
+
+    expect(component.address1).toEqual('Foo', 'county');
+    expect(component.address2).toEqual('Bar', 'subcounty');
+    expect(component.address3).not.toBeDefined(
+      'Initial value for estate (undefined)'
+    );
+    expect(component.cityVillage).toEqual(
+      'Quux',
+      'Initial value for city/village (undefined)'
+    );
+
+    fixture
+      .whenStable()
+      .then(() => {
+        countyInput.value = 'Municipio';
+        subcountyInput.value = 'Subcampo';
+        estateInput.value = 'Fazenda';
+        cityInput.value = 'Cidade';
+
+        countyInput.dispatchEvent(new Event('input'));
+        subcountyInput.dispatchEvent(new Event('input'));
+        estateInput.dispatchEvent(new Event('input'));
+        cityInput.dispatchEvent(new Event('input'));
+
+        click(saveBtn);
+
+        fixture.detectChanges();
+        return fixture.whenStable();
+      })
+      .then(() => {
+        expect(component.address1).toEqual('Municipio', 'county');
+        expect(component.address2).toEqual('Subcampo', 'subcounty');
+        expect(component.address3).toEqual('Fazenda', 'estate');
+        expect(component.cityVillage).toEqual('Cidade', 'city or village');
+        expect(saveUpdatePersonSpy).toHaveBeenCalledTimes(1);
+        expect(saveUpdatePersonSpy).toHaveBeenCalledWith(
+          'test-person-uuid',
+          jasmine.objectContaining({
+            addresses: jasmine.arrayContaining([
+              jasmine.objectContaining({ ...testPersonAddressPayload })
+            ])
+          })
+        );
+
+        const successMsg: HTMLDivElement = nativeElement.querySelector(
+          'div#successMsg'
+        );
+        expect(successMsg.innerText).toContain(
+          'Done! Address saved successfully'
+        );
+      });
+  }));
 });

--- a/src/app/patient-dashboard/common/patient-info/edit-address.component.spec.ts
+++ b/src/app/patient-dashboard/common/patient-info/edit-address.component.spec.ts
@@ -30,10 +30,12 @@ import { Patient } from '../../../models/patient.model';
 const testLocations = [
   {
     name: 'Test A',
+    stateProvince: 'Municipio',
     uuid: 'uuid1'
   },
   {
     name: 'Test B',
+    stateProvince: 'Condado',
     uuid: 'uuid2'
   }
 ];
@@ -195,8 +197,8 @@ describe('Component: EditAddressComponent Unit Tests', () => {
     ).and.callThrough();
 
     // Set new values for county, subcounty, estate and city
-    const countyInput: HTMLInputElement = nativeElement.querySelector(
-      'input#address1'
+    const countySelect: HTMLSelectElement = nativeElement.querySelector(
+      'select#address1'
     );
     const subcountyInput: HTMLInputElement = nativeElement.querySelector(
       'input#address2'
@@ -221,12 +223,12 @@ describe('Component: EditAddressComponent Unit Tests', () => {
     fixture
       .whenStable()
       .then(() => {
-        countyInput.value = 'Municipio';
+        countySelect.value = countySelect.options[0].value;
         subcountyInput.value = 'Subcampo';
         estateInput.value = 'Fazenda';
         cityInput.value = 'Cidade';
 
-        countyInput.dispatchEvent(new Event('input'));
+        countySelect.dispatchEvent(new Event('change'));
         subcountyInput.dispatchEvent(new Event('input'));
         estateInput.dispatchEvent(new Event('input'));
         cityInput.dispatchEvent(new Event('input'));

--- a/src/app/patient-dashboard/common/patient-info/edit-address.component.ts
+++ b/src/app/patient-dashboard/common/patient-info/edit-address.component.ts
@@ -38,9 +38,11 @@ export class EditAddressComponent implements OnInit, OnDestroy {
     private locationService: LocationResourceService,
     private personResourceService: PersonResourceService
   ) {}
+
   public ngOnInit(): void {
     this.getPatient();
   }
+
   public ngOnDestroy(): void {
     if (this.subscription.length) {
       this.subscription.map((sub) => sub.unsubscribe);
@@ -48,13 +50,13 @@ export class EditAddressComponent implements OnInit, OnDestroy {
   }
 
   public getPatient() {
-    const getLocationSubscription = this.locationService
-      .getAmpathLocations()
-      .subscribe((data) => {
-        this.locations = data;
-        console.log(data);
-      });
-    this.subscription.push(getLocationSubscription);
+    // const getLocationSubscription = this.locationService
+    //   .getAmpathLocations()
+    //   .subscribe((data) => {
+    //     this.locations = data;
+    //     console.log(data);
+    //   });
+    // this.subscription.push(getLocationSubscription);
     const getPatientSubscription = this.patientService.currentlyLoadedPatient.subscribe(
       (patient) => {
         this.patients = new Patient({});
@@ -108,7 +110,7 @@ export class EditAddressComponent implements OnInit, OnDestroy {
         }
       ]
     };
-    this.personResourceService
+    const saveUpdatePersonSub = this.personResourceService
       .saveUpdatePerson(person.uuid, personAddressPayload)
       .subscribe(
         (success) => {
@@ -121,13 +123,15 @@ export class EditAddressComponent implements OnInit, OnDestroy {
           }
         },
         (error) => {
-          console.error('error', error);
+          console.error('Error updating addresses: ', error);
           this.errors.push({
             id: 'patient',
             message: 'error updating address'
           });
         }
       );
+
+    this.subscription.push(saveUpdatePersonSub);
   }
   private displaySuccessAlert(message) {
     this.showErrorAlert = false;

--- a/src/app/patient-dashboard/common/patient-info/edit-address.component.ts
+++ b/src/app/patient-dashboard/common/patient-info/edit-address.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { PatientService } from '../../services/patient.service';
 import { Patient } from '../../../models/patient.model';
 import { PersonResourceService } from '../../../openmrs-api/person-resource.service';
@@ -11,7 +11,7 @@ import { LocationResourceService } from 'src/app/openmrs-api/location-resource.s
   styleUrls: []
 })
 export class EditAddressComponent implements OnInit, OnDestroy {
-  public patients: Patient = new Patient({});
+  public patient: Patient = new Patient({});
   public subscription: Subscription[] = [];
   public display = false;
   public address1: string;
@@ -59,25 +59,25 @@ export class EditAddressComponent implements OnInit, OnDestroy {
     // this.subscription.push(getLocationSubscription);
     const getPatientSubscription = this.patientService.currentlyLoadedPatient.subscribe(
       (patient) => {
-        this.patients = new Patient({});
+        this.patient = new Patient({});
         if (patient) {
-          this.patients = patient;
-          if (this.patients.person.preferredAddress) {
-            this.address1 = (this.patients.person
+          this.patient = patient;
+          if (this.patient.person.preferredAddress) {
+            this.address1 = (this.patient.person
               .preferredAddress as any).address1;
-            this.address2 = (this.patients.person
+            this.address2 = (this.patient.person
               .preferredAddress as any).address2;
-            this.address3 = (this.patients.person
+            this.address3 = (this.patient.person
               .preferredAddress as any).address3;
-            this.address7 = (this.patients.person
+            this.address7 = (this.patient.person
               .preferredAddress as any).address7;
-            this.cityVillage = (this.patients.person
+            this.cityVillage = (this.patient.person
               .preferredAddress as any).cityVillage;
-            this.latitude = (this.patients.person
+            this.latitude = (this.patient.person
               .preferredAddress as any).latitude;
-            this.longitude = (this.patients.person
+            this.longitude = (this.patient.person
               .preferredAddress as any).longitude;
-            this.preferredAddressUuid = (this.patients.person
+            this.preferredAddressUuid = (this.patient.person
               .preferredAddress as any).uuid;
           }
         }
@@ -89,12 +89,14 @@ export class EditAddressComponent implements OnInit, OnDestroy {
   public showDialog() {
     this.display = true;
   }
+
   public dismissDialog() {
     this.display = false;
   }
+
   public updatePersonAddress() {
     const person = {
-      uuid: this.patients.person.uuid
+      uuid: this.patient.person.uuid
     };
     const personAddressPayload = {
       addresses: [
@@ -133,6 +135,7 @@ export class EditAddressComponent implements OnInit, OnDestroy {
 
     this.subscription.push(saveUpdatePersonSub);
   }
+
   private displaySuccessAlert(message) {
     this.showErrorAlert = false;
     this.showSuccessAlert = true;
@@ -141,6 +144,7 @@ export class EditAddressComponent implements OnInit, OnDestroy {
       this.showSuccessAlert = false;
     }, 1000);
   }
+
   public setCounty(event) {
     this.address1 = event;
     const counties1 = this.locations.counties;
@@ -148,6 +152,7 @@ export class EditAddressComponent implements OnInit, OnDestroy {
       (county) => county.name === event
     ).subcounties;
   }
+
   public setSubCounty(event) {
     this.address2 = event;
     const subcounties = this.subcounties;
@@ -155,6 +160,7 @@ export class EditAddressComponent implements OnInit, OnDestroy {
       (subcounty) => subcounty.name === event
     ).wards;
   }
+
   public setWard(event) {
     this.address7 = event;
   }

--- a/src/app/patient-dashboard/common/patient-info/edit-address.component.ts
+++ b/src/app/patient-dashboard/common/patient-info/edit-address.component.ts
@@ -93,13 +93,12 @@ export class EditAddressComponent implements OnInit, OnDestroy {
       .subscribe(
         (locations: any[]) => {
           const counties: string[] = [];
-          // tslint:disable-next-line:prefer-for-of
-          for (let i = 0; i < locations.length; i++) {
+          for (const location of locations) {
             this.locations.push({
-              label: locations[i].name,
-              value: locations[i].uuid
+              label: location.name,
+              value: location.uuid
             });
-            counties.push(locations[i].stateProvince);
+            counties.push(location.stateProvince);
           }
           this.counties = _.uniq(counties);
           this.counties = _.remove(this.counties, (n) => {

--- a/src/app/test-helpers.ts
+++ b/src/app/test-helpers.ts
@@ -1,0 +1,25 @@
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, tick } from '@angular/core/testing';
+
+/** Button events to pass to `DebugElement.triggerEventHandler` for RouterLink event handler */
+const ButtonClickEvents = {
+  left: { button: 0 },
+  right: { button: 2 }
+};
+
+/** Simulate element click. Defaults to mouse left-button click event. */
+export function click(
+  el: DebugElement | HTMLElement,
+  eventObj: any = ButtonClickEvents.left
+): void {
+  if (el instanceof HTMLElement) {
+    el.click();
+  } else {
+    el.triggerEventHandler('click', eventObj);
+  }
+}
+
+export function tickAndDetectChanges(fixture: ComponentFixture<any>) {
+  fixture.detectChanges();
+  tick();
+}


### PR DESCRIPTION
https://jira.ampath.or.ke/browse/POCAMRS-443

Relates to: https://github.com/AMPATH/ng2-amrs/pull/1248 (Add OVC features to POC).

This PR **reverts** changes to the behavior of the `county` and `subcounty` fields in both the `patient registration` form and the `edit address` form. 

#1248 introduced dropdowns for selecting counties and subcounties but the available options were not exhaustive. To forestall potential further loss of this crucial information, [POCAMRS-443](https://jira.ampath.or.ke/browse/POCAMRS-443) proposes reverting back to the original logic as the team seeks a way to provide a more exhaustive list of options in the future when entering that data. 