### PR TITLE
POCAMRS-448: Fix free-text County input styling

### DIFF
--- a/src/app/patient-creation/patient-creation.component.html
+++ b/src/app/patient-creation/patient-creation.component.html
@@ -615,18 +615,24 @@
                   {{ county }}
                 </option>
               </select>
-              <div *ngIf="others">
-                <label for="address1" class="control-label"
-                  >County: Other (specify)</label
-                >
-                <input
-                  type="text"
-                  id="address1"
-                  class="form-control"
-                  [(ngModel)]="address1"
-                  name="address1"
-                />
-              </div>
+            </div>
+          </div>
+          <div
+            id="nonCodedCounty"
+            *ngIf="nonCodedCounty"
+            class="col-md-6 col-lg-6 col-sm-6 col-xs-6"
+          >
+            <div class="form-group">
+              <label for="address1" class="control-label"
+                >County: Other (specify)</label
+              >
+              <input
+                type="text"
+                id="address1NonCoded"
+                class="form-control"
+                [(ngModel)]="address1"
+                name="address1"
+              />
             </div>
           </div>
           <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">

--- a/src/app/patient-creation/patient-creation.component.ts
+++ b/src/app/patient-creation/patient-creation.component.ts
@@ -86,7 +86,7 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
   public longitude: string;
   public latitude: string;
   public stateProvince: string;
-  public others = false;
+  public nonCodedCounty = false;
 
   public patientIdentifiers = [];
   public patientIdentifier: string;
@@ -721,10 +721,10 @@ export class PatientCreationComponent implements OnInit, OnDestroy {
 
   public updateLocation(location) {
     if (location === 'Other') {
-      this.others = true;
+      this.nonCodedCounty = true;
       this.address1 = '';
     } else {
-      this.others = false;
+      this.nonCodedCounty = false;
     }
   }
 


### PR DESCRIPTION
Follow-up to #1334.  

This PR fixes styling of the `County` input field that is displayed when `Other` is selected as the county.

Before:
![Screenshot 2020-10-29 at 10 34 34](https://user-images.githubusercontent.com/8509731/97539083-76175800-19d2-11eb-9ff3-32e6e7167147.png)

After:
![Screenshot 2020-10-29 at 10 36 19](https://user-images.githubusercontent.com/8509731/97539194-9b0bcb00-19d2-11eb-9b2d-1c43de548ca6.png)
