### PR TITLE
Point travis status badge to new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-
-[![Build Status](https://travis-ci.org/AMPATH/ng2-amrs.svg?branch=master)](https://travis-ci.org/AMPATH/ng2-amrs)
+[![Build Status](https://travis-ci.com/AMPATH/ng2-amrs.svg?branch=master)](https://travis-ci.com/AMPATH/ng2-amrs)
 
 # AMPATH POC
 


### PR DESCRIPTION
This PR modifies the Travis status badge URLs to point to the new domain following the [migration](https://docs.travis-ci.com/user/migrate/open-source-repository-migration) of this repo's CI.