### PR TITLE
Adjust icon spacing

### DIFF
--- a/src/app/navigation/static-navbar/static-navbar.component.html
+++ b/src/app/navigation/static-navbar/static-navbar.component.html
@@ -3,13 +3,13 @@
     <ul class="nav navbar-nav">
       <li class="menu-left patient" routerLinkActive="active">
         <a routerLink="/patient-dashboard/patient-search">
-          <i class="fa fa-search"></i>
+          <i class="fa fa-search mr-1"></i>
           <span class="hidden-xs hidden-sm">Patient Search</span>
         </a>
       </li>
       <li class="menu-left clinic" routerLinkActive="active">
         <a routerLink="/clinic-dashboard">
-          <i class="fa fa-user-md"></i>
+          <i class="fa fa-user-md mr-1"></i>
           <span class="hidden-xs hidden-sm">Clinic Dashboard</span>
         </a>
       </li>
@@ -19,14 +19,14 @@
         routerLinkActive="trail"
       >
         <a dropdownToggle class="dropdown-toggle" data-toggle="dropdown">
-          <i class="fa fa-th"></i>
-          <span class="hidden-xs hidden-sm">More</span>
+          <i class="fa fa-th mr-1"></i>
+          <span class="hidden-xs hidden-sm mr-1">More</span>
           <span class="caret"></span>
         </a>
         <ul *dropdownMenu class="dropdown-menu">
           <li class="lab-order-search">
             <a routerLink="/lab-order-search" routerLinkActive="active">
-              <i class="icon-pathology"></i>
+              <i class="icon-pathology mr-1"></i>
               <span>Lab Order Search</span>
             </a>
           </li>
@@ -45,7 +45,7 @@
       >
         <a dropdownToggle class="dropdown-toggle" data-toggle="dropdown">
           <i class="fa fa-user"></i>
-          <span class="username hidden-xs">{{ user.display }}</span>
+          <span class="username hidden-xs mr-1">{{ user.display }}</span>
           <span class="caret"></span>
         </a>
         <ul *dropdownMenu class="dropdown-menu">

--- a/src/app/navigation/static-navbar/static-navbar.component.ts
+++ b/src/app/navigation/static-navbar/static-navbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { UserService } from '../../openmrs-api/user.service';
@@ -10,12 +10,13 @@ import { FormUpdaterService } from '../../patient-dashboard/common/formentry/for
 @Component({
   selector: 'static-navbar',
   templateUrl: './static-navbar.component.html',
-  styles: []
+  styles: ['.mr-1 { margin-right: 1rem }']
 })
 export class StaticNavBarComponent implements OnInit {
   public user: User;
   public userLocation = '';
   public department: any;
+
   constructor(
     private router: Router,
     private localStore: LocalStorageService,
@@ -32,6 +33,7 @@ export class StaticNavBarComponent implements OnInit {
       this.department = JSON.parse(department)[0].itemName;
     }
   }
+
   public logout() {
     this.router.navigateByUrl('/login').then((result) => {
       if (result) {
@@ -39,6 +41,7 @@ export class StaticNavBarComponent implements OnInit {
       }
     });
   }
+
   private setUserLocation() {
     this.user = this.userService.getLoggedInUser();
     this.userDefaultSettingsService.locationSubject.subscribe((location) => {

--- a/src/app/patient-search/patient-search.component.css
+++ b/src/app/patient-search/patient-search.component.css
@@ -5,6 +5,7 @@
 .input-group-btn > .btn {
   margin-left: 5px;
 }
+
 .patient-search {
   background: #fff;
   padding-top: 1%;
@@ -12,6 +13,7 @@
   margin-bottom: 10px;
   padding-bottom: 10px;
 }
+
 .input-group-btn {
   font-size: 14px;
 }

--- a/src/app/patient-search/patient-search.component.html
+++ b/src/app/patient-search/patient-search.component.html
@@ -29,10 +29,8 @@
                     class="btn btn-primary btn-lg search_btn"
                     (click)="loadPatient()"
                   >
-                    <span
-                      ><i class="glyphicon glyphicon-search"></i>
-                      <span>Search</span></span
-                    >
+                    <i class="glyphicon glyphicon-search"></i>
+                    <span>Search</span>
                     <i
                       *ngIf="isLoading"
                       class="fa fa-spinner fa-spin fa-1x fa-fw"
@@ -43,7 +41,8 @@
                     class="btn btn-danger btn-lg reset_btn"
                     (click)="resetSearchList()"
                   >
-                    <i class="fa fa-trash fa-fw"></i> <span>Reset</span>
+                    <i class="glyphicon glyphicon-trash"></i>
+                    <span>Reset</span>
                   </button>
                 </div>
               </div>
@@ -63,11 +62,11 @@
                 <div class="input-group-btn pl-right">
                   <button
                     [disabled]="isLoading"
-                    class="btn btn-primary btn-lg search_btn"
+                    class="btn btn-lg btn-primary"
                     style="margin-left: 0px"
                     (click)="loadPatient()"
                   >
-                    <span><i class="glyphicon glyphicon-search"></i></span>
+                    <i class="glyphicon glyphicon-search"></i>
                     <i
                       *ngIf="isLoading"
                       class="fa fa-spinner fa-spin fa-1x fa-fw"
@@ -75,10 +74,10 @@
                   </button>
                   <button
                     [disabled]="!isResetButton"
-                    class="btn btn-danger btn-lg reset_btn"
+                    class="btn btn-lg btn-danger"
                     (click)="resetSearchList()"
                   >
-                    <i class="fa fa-trash fa-fw"></i>
+                    <i class="glyphicon glyphicon-trash"></i>
                   </button>
                   <span
                     *ngIf="!hideRegistration"

--- a/src/app/shared/locations/location-filter/location-filter.component.html
+++ b/src/app/shared/locations/location-filter/location-filter.component.html
@@ -38,12 +38,12 @@
           <span
             style="cursor: pointer"
             *ngIf="showReset"
-            class="glyphicon glyphicon-trash"
+            class="glyphicon glyphicon-trash mr-1"
           ></span>
           <span
             style="cursor: pointer"
             *ngIf="!showReset"
-            class="glyphicon glyphicon-pushpin"
+            class="glyphicon glyphicon-pushpin mr-1"
           ></span>
           <span
             style="cursor: pointer"

--- a/src/app/shared/locations/location-filter/location-filter.component.ts
+++ b/src/app/shared/locations/location-filter/location-filter.component.ts
@@ -32,6 +32,9 @@ import * as _ from 'lodash';
       .ng-select .ng-arrow-zone {
         display: none;
       }
+      .mr-1 {
+        margin-right: 1rem;
+      }
     `
   ],
   encapsulation: ViewEncapsulation.None

--- a/src/app/shared/report-filters/report-filters.component.html
+++ b/src/app/shared/report-filters/report-filters.component.html
@@ -56,11 +56,11 @@
             <div>
               <span
                 *ngIf="selectedIndicatorTagsSelectedAll"
-                class="glyphicon glyphicon-trash"
+                class="glyphicon glyphicon-trash mr-1"
               ></span>
               <span
                 *ngIf="!selectedIndicatorTagsSelectedAll"
-                class="glyphicon glyphicon-pushpin"
+                class="glyphicon glyphicon-pushpin mr-1"
               ></span>
               <span *ngIf="!selectedIndicatorTagsSelectedAll">Select All</span>
               <span *ngIf="selectedIndicatorTagsSelectedAll">Select None</span>
@@ -215,11 +215,11 @@
               <div>
                 <span
                   *ngIf="selectedProgramTagsSelectedAll"
-                  class="glyphicon glyphicon-trash"
+                  class="glyphicon glyphicon-trash mr-1"
                 ></span>
                 <span
                   *ngIf="!selectedProgramTagsSelectedAll"
-                  class="glyphicon glyphicon-pushpin"
+                  class="glyphicon glyphicon-pushpin mr-1"
                 ></span>
                 <span *ngIf="!selectedProgramTagsSelectedAll">Select All</span>
                 <span *ngIf="selectedProgramTagsSelectedAll">Select None</span>

--- a/src/app/shared/report-filters/report-filters.component.ts
+++ b/src/app/shared/report-filters/report-filters.component.ts
@@ -37,6 +37,9 @@ import { SelectDepartmentService } from './../services/select-department.service
         flex-shrink: initial;
         background-color: #428bca !important;
       }
+      .mr-1 {
+        margin-right: 1rem;
+      }
     `
   ],
   encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
Spaces out glyphicons and their associated labels by adding `1rem` of margin to the right of the gylphicon.

Before:

![Screenshot 2021-01-04 at 14 52 54](https://user-images.githubusercontent.com/8509731/103532574-9238e900-4e9c-11eb-8e1e-c5395dc2d700.png)
![Screenshot 2021-01-04 at 14 26 25](https://user-images.githubusercontent.com/8509731/103531506-8b10db80-4e9a-11eb-9d4b-b7fa8c70d99f.png)

After:
![Screenshot 2021-01-04 at 14 27 18](https://user-images.githubusercontent.com/8509731/103531518-93691680-4e9a-11eb-969f-44598478a524.png)
![Screenshot 2021-01-04 at 14 37 01](https://user-images.githubusercontent.com/8509731/103531524-95cb7080-4e9a-11eb-8495-6620ecd7c277.png)

These adjustments do not affect the UI adversely when reduced to smaller breakpoints:

![Screenshot 2021-01-04 at 14 45 52](https://user-images.githubusercontent.com/8509731/103532099-ae885600-4e9b-11eb-97e3-c125c3e72590.png)
