### PR TITLE
Migrate from travis CI to Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: Ng2-amrs CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 10.x]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm i
+      - name: Install brfs
+        run: npm i -g brfs
+      - name: Linting
+        run: npm run lint
+      - name: Prettier check
+        run: npm run prettier:check
+      - name: Build prod
+        run: npm run build-prod
+      - name: Run headless tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: npm run test


### PR DESCRIPTION
Switch from Travis CI to Github actions mainly for fast builds, unlimited builds as well