### PR TITLE
Add json to lint staged glob patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,css,md,ts}": [
+    "*.{js,json,css,md,ts}": [
       "prettier --write",
       "ng lint ngx-amrs"
     ]


### PR DESCRIPTION
Add `json` file format to the glob patterns considered by lint-staged for automatic formatting pre-commit. This solves the problem of json files with lint errors leading to failing CI builds. Though we don't have a lot of json files on the frontend, modifying any one of these will lead to a failed CI build should one not format it manually using Prettier.