### PR TITLE
POC-1111: (chore) - add cd4 data and date in POC reports

### DIFF
--- a/src/app/clinic-schedule-lib/daily-schedule/daily-schedule-appointments.component.ts
+++ b/src/app/clinic-schedule-lib/daily-schedule/daily-schedule-appointments.component.ts
@@ -32,6 +32,16 @@ export class DailyScheduleAppointmentsComponent implements OnInit, OnDestroy {
       field: 'program'
     },
     {
+      headerName: 'CD4',
+      width: 150,
+      field: 'cd4_results'
+    },
+    {
+      headerName: 'CD4 Date',
+      width: 150,
+      field: 'cd4_date'
+    },
+    {
       headerName: 'ART start date',
       width: 120,
       field: 'arv_first_regimen_start_date'

--- a/src/app/clinic-schedule-lib/daily-schedule/daily-schedule-not-returned.component.ts
+++ b/src/app/clinic-schedule-lib/daily-schedule/daily-schedule-not-returned.component.ts
@@ -36,6 +36,16 @@ export class DailyScheduleNotReturnedComponent implements OnInit, OnDestroy {
       field: 'program'
     },
     {
+      headerName: 'CD4',
+      width: 150,
+      field: 'cd4_results'
+    },
+    {
+      headerName: 'CD4 Date',
+      width: 150,
+      field: 'cd4_date'
+    },
+    {
       headerName: 'ART start date',
       width: 120,
       field: 'arv_first_regimen_start_date'

--- a/src/app/clinic-schedule-lib/daily-schedule/daily-schedule-visits.component.ts
+++ b/src/app/clinic-schedule-lib/daily-schedule/daily-schedule-visits.component.ts
@@ -29,6 +29,16 @@ export class DailyScheduleVisitsComponent implements OnInit, OnDestroy {
       field: 'program'
     },
     {
+      headerName: 'CD4',
+      width: 150,
+      field: 'cd4_results'
+    },
+    {
+      headerName: 'CD4 Date',
+      width: 150,
+      field: 'cd4_date'
+    },
+    {
       headerName: 'ART start date',
       width: 120,
       field: 'arv_first_regimen_start_date'

--- a/src/app/hiv-care-lib/moh-731-report/moh-731-patientlist.component.ts
+++ b/src/app/hiv-care-lib/moh-731-report/moh-731-patientlist.component.ts
@@ -244,6 +244,8 @@ export class Moh731PatientListComponent implements OnInit, OnChanges {
       height: 'Height',
       stage: 'WHO Stage',
       location: 'Location',
+      cd4_1: 'CD4',
+      cd4_date: 'CD4 Date',
       enrollment_date: 'Enrollment Date',
       arv_first_regimen_start_date: 'ARVs Initial Start Date',
       cur_regimen_arv_start_date: 'Current ARV Regimen Start Date (edited)',


### PR DESCRIPTION
Add CD4 data and date in the following POC reports:

1. Monthly Schedule.
2. Daily Schedule.
3. MOH 731.
4. Gain & Losses.
5. Surge.